### PR TITLE
Support relative paths for exclude option

### DIFF
--- a/language-client/typescript.lisp
+++ b/language-client/typescript.lisp
@@ -21,20 +21,24 @@
   (uiop:close-streams (client-process client)))
 
 (defmethod references-client ((client language-client-typescript) pos)
-  (increment-req-id client)
-  (exec client (format nil "{\"seq\": ~a, \"command\": \"open\", \"arguments\": {\"file\": \"~a\"}}"
-                       (client-req-id client) (cdr (assoc :path pos))))
+  (let ((full-path (namestring
+                     (uiop:merge-pathnames* (cdr (assoc :path pos))
+                                            (client-path client)))))
+    (increment-req-id client)
+    (exec client (format nil "{\"seq\": ~a, \"command\": \"open\", \"arguments\": {\"file\": \"~a\"}}"
+                         (client-req-id client) full-path))
 
-  (increment-req-id client)
-  (let ((refs (exec-command client (format nil "{\"seq\": ~a, \"command\": \"references\", \"arguments\": {\"file\": \"~a\", \"line\": ~a, \"offset\": ~a}}"
-                              (client-req-id client) (cdr (assoc :path pos))
-                              (cdr (assoc :line pos)) (cdr (assoc :offset pos))))))
-    (mapcar (lambda (ref)
-              (list
-                (cons :path (jsown:val ref "file"))
-                (cons :line (jsown:val (jsown:val ref "start") "line"))
-                (cons :offset (jsown:val (jsown:val ref "start") "offset"))))
-            (jsown:val (jsown:val refs "body") "refs"))))
+    (increment-req-id client)
+    (let ((refs (exec-command client (format nil "{\"seq\": ~a, \"command\": \"references\", \"arguments\": {\"file\": \"~a\", \"line\": ~a, \"offset\": ~a}}"
+                                (client-req-id client) full-path
+                                (cdr (assoc :line pos)) (cdr (assoc :offset pos))))))
+      (mapcar (lambda (ref)
+                (list
+                  (cons :path (enough-namestring (jsown:val ref "file")
+                                                 (client-path client)))
+                  (cons :line (jsown:val (jsown:val ref "start") "line"))
+                  (cons :offset (jsown:val (jsown:val ref "start") "offset"))))
+              (jsown:val (jsown:val refs "body") "refs")))))
 
 (defmethod get-command ((client language-client-typescript) command)
   command)

--- a/main.lisp
+++ b/main.lisp
@@ -112,7 +112,7 @@
                                "*.ts" "*.tsx")
                     :exclude exclude
                     :lc (make-client :typescript front-path)
-                    :parser (make-parser :typescript)))
+                    :parser (make-parser :typescript front-path)))
       (start-client (context-lc front))
       (start-parser (context-parser front)))
     (when back-path
@@ -122,7 +122,7 @@
                    :include '("*.java")
                    :exclude exclude
                    :lc (make-client :java back-path)
-                   :parser (make-parser :java)))
+                   :parser (make-parser :java back-path)))
       (start-client (context-lc back))
       (initialize-client (context-lc back))
       (start-parser (context-parser back)))
@@ -156,7 +156,7 @@
       (let ((range (dequeue q)))
         (if (null range) (return results))
 
-        (let ((src-path (format nil "~a~a" (context-project-path ctx) (get-val range "path")))
+        (let ((src-path (get-val range "path"))
               ast)
           (setf ast (exec-parser (context-parser ctx) src-path))
           (setf results
@@ -171,7 +171,6 @@
             (mapcar (lambda (line-no)
                       (let ((item-pos
                               (find-affected-pos (context-parser ctx)
-                                                 (context-project-path ctx)
                                                  src-path ast line-no)))
                         (when item-pos
                           (acons :path src-path item-pos))))
@@ -193,13 +192,11 @@
     (if refs
         (loop for ref in refs
               do (let ((entrypoint (find-entrypoint (context-parser ctx)
-                                             (context-project-path ctx)
-                                             ref)))
+                                                    ref)))
                    (if entrypoint
                        (setf results (append results (list entrypoint)))
                        (enqueue q (list
-                                    (cons "path" (enough-namestring (cdr (assoc :path ref))
-                                                                    (context-project-path ctx)))
+                                    (cons "path" (cdr (assoc :path ref)))
                                     (cons "start" (cdr (assoc :line ref)))
                                     (cons "end" (cdr (assoc :line ref))))))))
         (setf results

--- a/parser/base.lisp
+++ b/parser/base.lisp
@@ -3,6 +3,7 @@
   (:export #:parser
            #:make-parser
            #:parser-process
+           #:parser-path
            #:start-parser
            #:stop-parser
            #:exec-parser
@@ -13,10 +14,12 @@
 
 (defclass parser ()
   ((process :initform nil
-            :accessor parser-process)))
+            :accessor parser-process)
+   (path :initarg :path
+         :accessor parser-path)))
 
-(defgeneric make-parser (kind)
-  (:method (kind)
+(defgeneric make-parser (kind path)
+  (:method (kind path)
     (error 'unknown-parser :name kind)))
 
 (defgeneric start-parser (parser))
@@ -25,9 +28,9 @@
 
 (defgeneric exec-parser (parser file-path))
 
-(defgeneric find-affected-pos (parser project-path file-path ast line-no))
+(defgeneric find-affected-pos (parser file-path ast line-no))
 
-(defgeneric find-entrypoint (parser project-path pos))
+(defgeneric find-entrypoint (parser pos))
 
 (defun exec-command (parser command)
   (write-line command (uiop:process-info-input (parser-process parser)))

--- a/parser/java.lisp
+++ b/parser/java.lisp
@@ -8,8 +8,9 @@
 (defclass parser-java (parser)
   ())
 
-(defmethod make-parser ((kind (eql :java)))
-  (make-instance 'parser-java))
+(defmethod make-parser ((kind (eql :java)) path)
+  (make-instance 'parser-java
+                 :path path))
 
 (defmethod start-parser ((parser parser-java))
   (setf (parser-process parser)
@@ -22,11 +23,12 @@
   (uiop:close-streams (parser-process parser)))
 
 (defmethod exec-parser ((parser parser-java) file-path)
-  (let ((ast (exec-command parser file-path)))
+  (let ((ast (exec-command parser (namestring
+                                    (uiop:merge-pathnames* file-path (parser-path parser))))))
     (when (> (length ast) 0)
       (cdr (jsown:parse ast)))))
 
-(defmethod find-affected-pos ((parser parser-java) project-path src-path ast line-no)
+(defmethod find-affected-pos ((parser parser-java) src-path ast line-no)
   (let ((q (make-queue)))
     (enqueue q ast)
     (loop
@@ -52,5 +54,5 @@
           (loop for member in (jsown:val ast "members") do
                 (enqueue q (cdr member))))))))
 
-(defmethod find-entrypoint ((parser parser-java) project-path pos))
+(defmethod find-entrypoint ((parser parser-java) pos))
 

--- a/test/file.lisp
+++ b/test/file.lisp
@@ -25,7 +25,7 @@
 (test not-analyze-when-the-parent-directory-matches-exclude
   (is (equal
         nil
-        (is-analysis-target "App/test/App.test.js" '("*.js") '("**/test/*")))))
+        (is-analysis-target "App/test/App.test.js" '("*.js") '("App/test/*")))))
 
 (test analyze-when-not-excluded
   (is (equal

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -61,7 +61,7 @@
 (test analyze-by-range-in-external-function-for-back
   (multiple-value-bind (front back) (inga/main::start
                                       :back-path *back-path*
-                                      :exclude '("*Test.java"))
+                                      :exclude '("src/test/**"))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
              (:name . "getArticles") (:line . 48) (:offset . 3)))
@@ -74,7 +74,7 @@
 (test analyze-by-range-in-nested-external-function-for-back
   (multiple-value-bind (front back) (inga/main::start
                                       :back-path *back-path*
-                                      :exclude '("*Test.java"))
+                                      :exclude '("src/test/**"))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
              (:name . "createArticle") (:line . 28) (:offset . 3))
@@ -89,7 +89,7 @@
 (test analyze-by-range-in-interface-for-back
   (multiple-value-bind (front back) (inga/main::start
                                       :back-path *back-path*
-                                      :exclude '("*Test.java"))
+                                      :exclude '("src/test/**"))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
              (:name . "createArticle") (:line . 28) (:offset . 3))

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -15,8 +15,8 @@
                             "src/App/NewTodoInput/index.tsx" *project-path*))
               '(:pos . 1241))
         (inga/parser/typescript::convert-to-ast-pos
-          (list (cons :path (uiop:merge-pathnames*
-                              "src/App/NewTodoInput/index.tsx" *project-path*))
+          *project-path*
+          (list '(:path . "src/App/NewTodoInput/index.tsx")
                 '(:line . 39) '(:offset . 69))))))
 
 (test convert-tsparser-pos-to-tsserver-pos
@@ -25,6 +25,6 @@
               '(:name . "a") '(:line . 39) '(:offset . 69))
         (inga/parser/typescript::convert-to-pos
           *project-path*
-          (uiop:merge-pathnames* "src/App/NewTodoInput/index.tsx" *project-path*)
+          "src/App/NewTodoInput/index.tsx"
           "a" 1241))))
 


### PR DESCRIPTION
Changed `--exclude` option to allow relative paths such as `src/test/**`.