### PR TITLE
Support for multi-byte content

### DIFF
--- a/language-client/base.lisp
+++ b/language-client/base.lisp
@@ -1,6 +1,7 @@
 (defpackage #:inga/language-client/base
   (:use #:cl)
   (:import-from #:jsown)
+  (:import-from #:flexi-streams)
   (:export #:language-client
            #:make-client
            #:client-process
@@ -64,8 +65,8 @@
     (read-line stream)
     ;; JSON
     (loop
-      with result = ""
+      with buff = (make-array len :fill-pointer 0)
       repeat len
-      do (setf result (format nil "~a~a" result (read-char stream)))
-      finally (return result))))
+      do (vector-push (read-byte stream) buff)
+      finally (return (flexi-streams:octets-to-string buff :external-format :utf-8)))))
 

--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -101,7 +101,10 @@
                (equal (jsown:val ast "kind") *jsx-self-closing-element*)))
     (setf (parser-nearest-ast-pos parser)
           (list
-            (cons :name (jsown:val (cdr (jsown:val ast "tagName")) "escapedText"))
+            (cons :name (let ((tag-name (cdr (jsown:val ast "tagName"))))
+                          (if (jsown:keyp tag-name "escapedText")
+                              (jsown:val tag-name "escapedText")
+                              "")))
             (cons :pos (+ (jsown:val ast "start") 1)))))
 
   (when (not (null ast))


### PR DESCRIPTION
Fixed to read byte counts instead of character counts because multibyte characters in the LSP results prevent all content from being read.