### PR TITLE
Support for finding affected variables

### DIFF
--- a/inga.asd
+++ b/inga.asd
@@ -9,7 +9,6 @@
 (defsystem "inga/test"
   :class :package-inferred-system
   :depends-on ("fiveam"
-               "inga/test/parser/typescript"
                "inga/test/jsx"
                "inga/test/git"
                "inga/test/github"

--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -8,6 +8,7 @@
 ;; typescript v4.3.5
 (defparameter *void-keyword* 113)
 (defparameter *method-declaration* 166)
+(defparameter *object-literal-expression* 201)
 (defparameter *parenthesized-expression* 208)
 (defparameter *arrow-function* 210)
 (defparameter *variable-statement* 233)
@@ -59,12 +60,17 @@
                 (jsown:keyp ast "start") (<= (jsown:val ast "start") ast-pos)
                 (jsown:keyp ast "end") (> (jsown:val ast "end") ast-pos))
           (let ((init (jsown:val ast "initializer")))
-            (when (= (jsown:val init "kind") *arrow-function*)
-              (if (equal (find-return-type init) *jsx-element*)
-                  (enqueue q (jsown:val init "body"))
-                  (return (convert-to-pos (parser-path parser) file-path
-                                          (jsown:val (cdr (jsown:val ast "name")) "escapedText")
-                                          (jsown:val ast "start")))))))
+            (alexandria:switch ((jsown:val init "kind"))
+              (*object-literal-expression*
+               (return (convert-to-pos (parser-path parser) file-path
+                                       (jsown:val (cdr (jsown:val ast "name")) "escapedText")
+                                       (jsown:val ast "start"))))
+              (*arrow-function*
+                (if (equal (find-return-type init) *jsx-element*)
+                    (enqueue q (jsown:val init "body"))
+                    (return (convert-to-pos (parser-path parser) file-path
+                                            (jsown:val (cdr (jsown:val ast "name")) "escapedText")
+                                            (jsown:val ast "start"))))))))
 
         (when (and
                 (jsown:keyp ast "kind") (= (jsown:val ast "kind") *function-declaration*)

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -1,21 +1,64 @@
 (defpackage #:inga/test/parser/typescript
   (:use #:cl
         #:fiveam
-        #:inga/parser/typescript))
+        #:inga/parser))
 (in-package #:inga/test/parser/typescript)
 
 (def-suite parser/typescript)
 (in-suite parser/typescript)
 
-(defparameter *project-path* (uiop:merge-pathnames* "test/fixtures/react-typescript-todo/"))
+(defparameter *react-path* (uiop:merge-pathnames* "test/fixtures/react-typescript-todo/"))
+(defparameter *nestjs-path* (uiop:merge-pathnames* "test/fixtures/nestjs-realworld-example-app-prisma/"))
+
+(test find-affected-pos-for-variable-object-literal-expression
+  (let ((parser (make-parser :typescript *nestjs-path*)))
+    (start-parser parser)
+    (is (equal
+          '((:path . "src/article/article.service.ts")
+            (:name . "articleAuthorSelect") (:line . 7) (:offset . 7))
+          (let ((src-path "src/article/article.service.ts"))
+            (inga/parser/typescript::find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              8))))
+    (stop-parser parser)))
+
+(test find-affected-pos-for-variable-arrow-function
+  (let ((parser (make-parser :typescript *react-path*)))
+    (start-parser parser)
+    (is (equal
+          '((:path . "src/App/TodoList/Item/index.tsx")
+            (:name . "reverseCompleted") (:line . 62) (:offset . 9))
+          (let ((src-path "src/App/TodoList/Item/index.tsx"))
+            (inga/parser/typescript::find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              65))))
+    (stop-parser parser)))
+
+(test find-affected-pos-for-method
+  (let ((parser (make-parser :typescript *nestjs-path*)))
+    (start-parser parser)
+    (is (equal
+          '((:path . "src/article/article.service.ts")
+            (:name . "findAll") (:line . 45) (:offset . 3))
+          (let ((src-path "src/article/article.service.ts"))
+            (inga/parser/typescript::find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              47))))
+    (stop-parser parser)))
 
 (test convert-tsserver-pos-to-tsparser-pos
   (is (equal
         (list (cons :path (uiop:merge-pathnames*
-                            "src/App/NewTodoInput/index.tsx" *project-path*))
+                            "src/App/NewTodoInput/index.tsx" *react-path*))
               '(:pos . 1241))
         (inga/parser/typescript::convert-to-ast-pos
-          *project-path*
+          *react-path*
           (list '(:path . "src/App/NewTodoInput/index.tsx")
                 '(:line . 39) '(:offset . 69))))))
 
@@ -24,7 +67,7 @@
         (list '(:path . "src/App/NewTodoInput/index.tsx")
               '(:name . "a") '(:line . 39) '(:offset . 69))
         (inga/parser/typescript::convert-to-pos
-          *project-path*
+          *react-path*
           "src/App/NewTodoInput/index.tsx"
           "a" 1241))))
 


### PR DESCRIPTION
Can be traced when the following is changed

For example:
```ts
const articleAuthorSelect = {
  email: true, // here!
  username: true,
  bio: true,
  image: true,
  followedBy: { select: { id: true } }
};
```