### PR TITLE
Add debug log

### DIFF
--- a/all.lisp
+++ b/all.lisp
@@ -5,5 +5,6 @@
     #:inga/jsx
     #:inga/git
     #:inga/file
-    #:inga/errors))
+    #:inga/errors
+    #:inga/logger))
 

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -65,6 +65,7 @@ RUN set -eux && \
   apt install -y openjdk-17-jdk
 
 ENV INGA_HOME /
+ENV INGA_DEBUG 1
 
 ENTRYPOINT ["inga"]
 

--- a/docker/typescript/Dockerfile
+++ b/docker/typescript/Dockerfile
@@ -70,6 +70,7 @@ RUN set -eux && \
   npm install -g .
 
 ENV INGA_HOME /
+ENV INGA_DEBUG 1
 
 ENTRYPOINT ["inga"]
 

--- a/logger.lisp
+++ b/logger.lisp
@@ -3,10 +3,7 @@
    (:export #:log-debug))
 (in-package #:inga/logger)
 
-(defparameter *debug* (when (uiop:getenv "INGA_DEBUG") t))
-
 (defun log-debug (content)
-  (format t "env debug: ~a, debug: ~a~%" (uiop:getenv "INGA_DEBUG") *debug*)
-  (when *debug*
+  (when (uiop:getenv "INGA_DEBUG")
     (format t "~&~a~%" content)))
 

--- a/logger.lisp
+++ b/logger.lisp
@@ -1,0 +1,11 @@
+(defpackage #:inga/logger
+   (:use #:cl)
+   (:export #:log-debug))
+(in-package #:inga/logger)
+
+(defparameter *debug* (when (uiop:getenv "INGA_DEBUG") t))
+
+(defun log-debug (content)
+  (when *debug*
+    (format t "~&~a~%" content)))
+

--- a/logger.lisp
+++ b/logger.lisp
@@ -6,6 +6,7 @@
 (defparameter *debug* (when (uiop:getenv "INGA_DEBUG") t))
 
 (defun log-debug (content)
+  (format t "env debug: ~a, debug: ~a~%" (uiop:getenv "INGA_DEBUG") *debug*)
   (when *debug*
     (format t "~&~a~%" content)))
 

--- a/main.lisp
+++ b/main.lisp
@@ -21,6 +21,8 @@
                 #:find-entrypoint)
   (:import-from #:inga/errors
                 #:inga-error)
+  (:import-from #:inga/logger
+                #:log-debug)
   (:export #:command))
 (in-package #:inga/main)
 
@@ -51,7 +53,7 @@
 
         (let ((ctx (start root-path (get-analysis-kinds diffs) exclude)))
           (let ((results (analyze ctx diffs)))
-            (format t "~a~%" results)
+            (log-debug (format nil "results: ~a" results))
             (when (and pr results)
               (destructuring-bind (&key base-url owner-repo number base-ref-name head-sha) pr
                 (inga/github:send-pr-comment hostname base-url owner-repo number results root-path head-sha))))
@@ -168,6 +170,7 @@
                               (find-affected-pos (context-parser ctx)
                                                  src-path ast line-no)))
                         (when item-pos
+                          (log-debug (format nil "affected-pos: ~a, src-path: ~a, line-no: ~a" item-pos src-path line-no))
                           (acons :path src-path item-pos))))
                     (loop for line-no
                           from (cdr (assoc :start range))
@@ -184,6 +187,7 @@
                                                                (context-exclude ctx))
                                        ref))
                                    refs)))
+    (log-debug (format nil "references: ~a, pos: ~a" refs pos))
     (if refs
         (loop for ref in refs
               do (let ((entrypoint (find-entrypoint (context-parser ctx)

--- a/main.lisp
+++ b/main.lisp
@@ -130,13 +130,14 @@
 
 (defun get-analysis-kinds (diffs)
   (remove nil
-          (mapcar (lambda (diff)
-                    (if (is-match (cdr (assoc :path diff)) *include-typescript*)
-                        :typescript
-                        (if (is-match (cdr (assoc :path diff)) *include-java*)
-                            :java
-                            nil)))
-                  diffs)))
+          (remove-duplicates
+            (mapcar (lambda (diff)
+                      (if (is-match (cdr (assoc :path diff)) *include-typescript*)
+                          :typescript
+                          (if (is-match (cdr (assoc :path diff)) *include-java*)
+                              :java
+                              nil)))
+                    diffs))))
 
 (defun analyze (ctx diffs)
   (remove-duplicates

--- a/main.lisp
+++ b/main.lisp
@@ -103,6 +103,7 @@
         (list sequence))))
 
 (defun start (root-path kinds &optional (exclude '()))
+  (log-debug (format nil "found context: ~a" kinds))
   (let ((ctx (alexandria:switch ((when (> (length kinds) 0) (first kinds)))
                (:typescript
                  (make-context

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -120,7 +120,9 @@
         '(:java)
         (inga/main::get-analysis-kinds
           '(((:path . "src/main/java/io/spring/application/article/NewArticleParam.java")
-             (:start . 18) (:end . 18)))))))
+             (:start . 18) (:end . 18))
+            ((:path . "src/main/java/io/spring/application/article/NewArticleParam.java")
+             (:start . 20) (:end . 20)))))))
 
 (test throw-error-when-option-does-not-exist
   (signals inga/main::inga-error-option-not-found


### PR DESCRIPTION
Turn on debug logging by default for a while to make it easier to debug analysis results.