### PR TITLE
Analyze only matching env context

### DIFF
--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -65,6 +65,7 @@ RUN set -eux && \
   apt install -y openjdk-17-jdk
 
 ENV INGA_HOME /
+ENV INGA_CONTEXT java
 ENV INGA_DEBUG 1
 
 ENTRYPOINT ["inga"]

--- a/docker/typescript/Dockerfile
+++ b/docker/typescript/Dockerfile
@@ -70,6 +70,7 @@ RUN set -eux && \
   npm install -g .
 
 ENV INGA_HOME /
+ENV INGA_CONTEXT typescript
 ENV INGA_DEBUG 1
 
 ENTRYPOINT ["inga"]

--- a/main.lisp
+++ b/main.lisp
@@ -137,7 +137,7 @@
     (remove nil
             (remove-duplicates
               (mapcar (lambda (kind)
-                        (alexandria:switch (kind)
+                        (alexandria:switch (kind :test #'equal)
                           ("typescript" :typescript)
                           ("java" :java)))
                       kinds)))))

--- a/main.lisp
+++ b/main.lisp
@@ -131,9 +131,7 @@
                     diffs))))
 
 (defun get-env-kinds ()
-  (log-debug (format nil "env: ~a" (uiop:getenv "INGA_CONTEXT")))
   (let ((kinds (split-trim-comma (uiop:getenv "INGA_CONTEXT"))))
-    (log-debug (format nil "trimmed env: ~a" kinds))
     (remove nil
             (remove-duplicates
               (mapcar (lambda (kind)

--- a/main.lisp
+++ b/main.lisp
@@ -131,7 +131,9 @@
                     diffs))))
 
 (defun get-env-kinds ()
+  (log-debug (format nil "env: ~a" (uiop:getenv "INGA_CONTEXT")))
   (let ((kinds (split-trim-comma (uiop:getenv "INGA_CONTEXT"))))
+    (log-debug (format nil "trimmed env: ~a" kinds))
     (remove nil
             (remove-duplicates
               (mapcar (lambda (kind)

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -124,6 +124,18 @@
             ((:path . "src/main/java/io/spring/application/article/NewArticleParam.java")
              (:start . 20) (:end . 20)))))))
 
+(test filter-active-context-with-no-env
+  (is (equal
+        '(:java)
+        (inga/main::filter-active-context
+          '(:java) nil))))
+
+(test filter-active-context-with-java-env
+  (is (equal
+        '(:java)
+        (inga/main::filter-active-context
+          '(:typescript :java) '(:java)))))
+
 (test throw-error-when-option-does-not-exist
   (signals inga/main::inga-error-option-not-found
     (inga/main::parse-argv '("--not-exist"))))

--- a/utils.lisp
+++ b/utils.lisp
@@ -2,7 +2,9 @@
   (:use #:cl)
   (:export #:make-queue
            #:enqueue
-           #:dequeue))
+           #:dequeue
+           #:split
+           #:split-trim-comma))
 (in-package #:inga/utils)
 
 (defstruct queue
@@ -16,6 +18,18 @@
 (defun dequeue (q)
   (unless (null (queue-values q))
     (pop (queue-values q))))
+
+(defun split (div sequence)
+  (let ((pos (position div sequence)))
+    (if pos
+        (list* (subseq sequence 0 pos)
+               (split div (subseq sequence (1+ pos))))
+        (list sequence))))
+
+(defun split-trim-comma (sequence)
+  (mapcar (lambda (str)
+            (string-trim '(#\Space) str))
+          (split #\, sequence)))
 
 ;; for debug
 (defun top (sequence limit)


### PR DESCRIPTION
Add a check because it will not work properly if the dependent library (language server, parser) does not exist in the execution environment.