### PR TITLE
Ignore function deletions

### DIFF
--- a/language-client/typescript.lisp
+++ b/language-client/typescript.lisp
@@ -32,13 +32,16 @@
     (let ((refs (exec-command client (format nil "{\"seq\": ~a, \"command\": \"references\", \"arguments\": {\"file\": \"~a\", \"line\": ~a, \"offset\": ~a}}"
                                 (client-req-id client) full-path
                                 (cdr (assoc :line pos)) (cdr (assoc :offset pos))))))
-      (mapcar (lambda (ref)
-                (list
-                  (cons :path (enough-namestring (jsown:val ref "file")
-                                                 (client-path client)))
-                  (cons :line (jsown:val (jsown:val ref "start") "line"))
-                  (cons :offset (jsown:val (jsown:val ref "start") "offset"))))
-              (jsown:val (jsown:val refs "body") "refs")))))
+      (remove nil
+              (mapcar (lambda (ref)
+                        (let ((ref-pos (list
+                                         (cons :path (enough-namestring (jsown:val ref "file")
+                                                                        (client-path client)))
+                                         (cons :line (jsown:val (jsown:val ref "start") "line"))
+                                         (cons :offset (jsown:val (jsown:val ref "start") "offset")))))
+                          (unless (= (cdr (assoc :line ref-pos)) (cdr (assoc :line pos)))
+                            ref-pos)))
+                      (jsown:val (jsown:val refs "body") "refs"))))))
 
 (defmethod get-command ((client language-client-typescript) command)
   command)

--- a/main.lisp
+++ b/main.lisp
@@ -201,14 +201,14 @@
     (log-debug (format nil "references: ~a, pos: ~a" refs pos))
     (if refs
         (loop for ref in refs
-              do (let ((entrypoint (find-entrypoint (context-parser ctx)
-                                                    ref)))
-                   (if entrypoint
-                       (setf results (append results (list entrypoint)))
-                       (enqueue q (list
-                                    (cons :path (cdr (assoc :path ref)))
-                                    (cons :start (cdr (assoc :line ref)))
-                                    (cons :end (cdr (assoc :line ref))))))))
+              do (progn 
+                   (let ((entrypoint (find-entrypoint (context-parser ctx) ref)))
+                     (if entrypoint
+                         (setf results (append results (list entrypoint)))
+                         (enqueue q (list
+                                      (cons :path (cdr (assoc :path ref)))
+                                      (cons :start (cdr (assoc :line ref)))
+                                      (cons :end (cdr (assoc :line ref)))))))))
         (setf results
               (list
                 (list (cons :path (enough-namestring (cdr (assoc :path pos))

--- a/parser/java.lisp
+++ b/parser/java.lisp
@@ -41,7 +41,7 @@
                   (string= (cdr (car ast)) "com.github.javaparser.ast.body.ConstructorDeclaration")
                   (string= (cdr (car ast)) "com.github.javaparser.ast.body.MethodDeclaration"))
                 (<= (jsown:val (jsown:val ast "range") "beginLine") line-no)
-                (>= (jsown:val (jsown:val ast "range") "endLine") line-no))
+                (> (jsown:val (jsown:val ast "range") "endLine") line-no))
           (return
             (list (cons :name (if (jsown:keyp ast "name")
                                   (jsown:val (cdr (jsown:val ast "name")) "identifier")

--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -49,7 +49,7 @@
                                     (list
                                       (cons :path file-path)
                                       (cons :line line-no)
-                                      (cons :offset 0)))))))
+                                      (cons :offset -1)))))))
     (enqueue q ast)
     (loop
       (let ((ast (dequeue q)))
@@ -176,6 +176,7 @@
 
 (defun convert-to-ast-pos (project-path pos)
   (let ((path (uiop:merge-pathnames* (cdr (assoc :path pos)) project-path))
+        (offset (cdr (assoc :offset pos)))
         (line-no 0)
         (result 0))
     (with-open-file (stream path)
@@ -184,7 +185,9 @@
             when (= line-no (- (cdr (assoc :line pos)) 1))
             return (list
                      (cons :path (pathname path))
-                     (cons :pos (- (+ result (cdr (assoc :offset pos))) 1)))
+                     (cons :pos (+ result (if (< offset 0)
+                                              (length line)
+                                              offset))))
             do
             (setq line-no (+ line-no 1))
             ;; add newline code

--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -187,7 +187,7 @@
                      (cons :path (pathname path))
                      (cons :pos (+ result (if (< offset 0)
                                               (length line)
-                                              offset))))
+                                              (- offset 1)))))
             do
             (setq line-no (+ line-no 1))
             ;; add newline code

--- a/test/parser/java.lisp
+++ b/test/parser/java.lisp
@@ -1,0 +1,25 @@
+(defpackage #:inga/test/parser/java
+  (:use #:cl
+        #:fiveam
+        #:inga/parser))
+(in-package #:inga/test/parser/java)
+
+(def-suite parser/java)
+(in-suite parser/java)
+
+(defparameter *spring-boot-path*
+  (truename (uiop:merge-pathnames* "test/fixtures/spring-boot-realworld-example-app/")))
+
+(test ignore-affected-pos-when-end-block
+  (let ((parser (make-parser :java *spring-boot-path*)))
+    (start-parser parser)
+    (is (equal
+          nil
+          (let ((src-path "src/main/java/io/spring/core/article/Article.java"))
+            (inga/parser/java::find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              65))))
+    (stop-parser parser)))
+

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -52,11 +52,24 @@
               47))))
     (stop-parser parser)))
 
+(test ignore-affected-pos-when-end-block
+  (let ((parser (make-parser :typescript *nestjs-path*)))
+    (start-parser parser)
+    (is (equal
+          nil
+          (let ((src-path "src/article/article.service.ts"))
+            (inga/parser/typescript::find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              150))))
+    (stop-parser parser)))
+
 (test convert-tsserver-pos-to-tsparser-pos
   (is (equal
         (list (cons :path (uiop:merge-pathnames*
                             "src/App/NewTodoInput/index.tsx" *react-path*))
-              '(:pos . 1241))
+              '(:pos . 1242))
         (inga/parser/typescript::convert-to-ast-pos
           *react-path*
           (list '(:path . "src/App/NewTodoInput/index.tsx")

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -69,7 +69,7 @@
   (is (equal
         (list (cons :path (uiop:merge-pathnames*
                             "src/App/NewTodoInput/index.tsx" *react-path*))
-              '(:pos . 1242))
+              '(:pos . 1241))
         (inga/parser/typescript::convert-to-ast-pos
           *react-path*
           (list '(:path . "src/App/NewTodoInput/index.tsx")


### PR DESCRIPTION
Ignore the case of an end block, since deleting a function will accidentally affect one block above it.