### PR TITLE
Fix a conversion error in the AST position

### DIFF
--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -199,7 +199,7 @@
     (with-open-file (stream (uiop:merge-pathnames* path project-path))
       (loop for line = (read-line stream nil)
             while line
-            when (<= pos (+ cnt (length line) 1))
+            when (<= pos (+ cnt (length line)))
             return (list
                      (cons :path (enough-namestring path project-path))
                      (cons :name name)

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -84,3 +84,22 @@
           "src/App/NewTodoInput/index.tsx"
           "a" 1241))))
 
+(test convert-tsserver-pos-to-tsparser-pos-with-offset1
+  (is (equal
+        (list (cons :path (uiop:merge-pathnames*
+                            "src/dataStructure.ts" *react-path*))
+              '(:pos . 328))
+        (inga/parser/typescript::convert-to-ast-pos
+          *react-path*
+          (list '(:path . "src/dataStructure.ts")
+                '(:line . 21) '(:offset . 1))))))
+
+(test convert-tsparser-pos-to-tsserver-pos-with-offset1
+  (is (equal
+        (list '(:path . "src/dataStructure.ts")
+              '(:name . "a") '(:line . 21) '(:offset . 1))
+        (inga/parser/typescript::convert-to-pos
+          *react-path*
+          "src/dataStructure.ts"
+          "a" 328))))
+


### PR DESCRIPTION
The conversion of offset 1 position to AST position was out of alignment, corrected.

```ts
↓
function LoadAppStateFromLocalStorage(): AppState {
  //...
```