### PR TITLE
Fix fail when branch name and directory name are the same

### DIFF
--- a/git.lisp
+++ b/git.lisp
@@ -8,7 +8,7 @@
 
 (defun get-diff (project-path base-sha)
   (let ((diff (uiop:run-program
-                (format nil "(cd ~a && git diff ~a --unified=0)" project-path base-sha)
+                (format nil "(cd ~a && git diff ~a --unified=0 --)" project-path base-sha)
                 :output :string)))
 
     (let ((ranges (make-array 10 :fill-pointer 0 :adjustable t)) to-path)


### PR DESCRIPTION
Fixes #25 