### PR TITLE
Returns function name position

### DIFF
--- a/parser/java.lisp
+++ b/parser/java.lisp
@@ -48,16 +48,18 @@
                     (= (jsown:val (jsown:val ast "range") "endLine") line-no)
                     (jsown:keyp ast "tokenRange")
                     (= (jsown:val (jsown:val (jsown:val ast "tokenRange") "endToken") "kind") *java-rbrace**))
-            (return
-              (list (cons :name (if (jsown:keyp ast "name")
-                                    (jsown:val (cdr (jsown:val ast "name")) "identifier")
-                                    (if (jsown:keyp ast "variables")
-                                        (jsown:val 
-                                          (jsown:val (cdr (first (jsown:val ast "variables"))) "name")
-                                          "identifier")
-                                        "")))
-                    (cons :line (jsown:val (jsown:val ast "range") "beginLine"))
-                    (cons :offset (jsown:val (jsown:val ast "range") "beginColumn"))))))
+            (when (jsown:keyp ast "name")
+              (let ((name (cdr (jsown:val ast "name"))))
+                (return
+                  (list (cons :name (jsown:val name "identifier"))
+                        (cons :line (jsown:val (jsown:val name "range") "beginLine"))
+                        (cons :offset (jsown:val (jsown:val name "range") "beginColumn"))))))
+            (when (jsown:keyp ast "variables")
+              (let ((name (cdr (jsown:val (cdr (first (jsown:val ast "variables"))) "name"))))
+                (return
+                  (list (cons :name (jsown:val name "identifier"))
+                        (cons :line (jsown:val (jsown:val name "range") "beginLine"))
+                        (cons :offset (jsown:val (jsown:val name "range") "beginColumn"))))))))
 
         (when (jsown:keyp ast "types")
           (loop for type in (jsown:val ast "types") do

--- a/parser/typescript.lisp
+++ b/parser/typescript.lisp
@@ -63,9 +63,11 @@
           (let ((init (jsown:val ast "initializer")))
             (alexandria:switch ((jsown:val init "kind"))
               (*object-literal-expression*
-               (return (convert-to-pos (parser-path parser) file-path
-                                       (jsown:val (cdr (jsown:val ast "name")) "escapedText")
-                                       (jsown:val ast "start"))))
+                (when (jsown:keyp ast "name")
+                  (let ((name (cdr (jsown:val ast "name"))))
+                    (return (convert-to-pos (parser-path parser) file-path
+                                            (jsown:val name "escapedText")
+                                            (jsown:val name "start"))))))
               (*arrow-function*
                 (if (equal (find-return-type init) *jsx-element*)
                     (enqueue q (jsown:val init "body"))
@@ -77,17 +79,21 @@
                 (jsown:keyp ast "kind") (= (jsown:val ast "kind") *function-declaration*)
                 (jsown:keyp ast "start") (<= (jsown:val ast "start") ast-pos)
                 (jsown:keyp ast "end") (> (jsown:val ast "end") ast-pos))
-          (return (convert-to-pos (parser-path parser) file-path
-                                  (jsown:val (cdr (jsown:val ast "name")) "escapedText")
-                                  (jsown:val ast "start"))))
+          (when (jsown:keyp ast "name")
+            (let ((name (cdr (jsown:val ast "name"))))
+              (return (convert-to-pos (parser-path parser) file-path
+                                      (jsown:val name "escapedText")
+                                      (jsown:val name "start"))))))
 
         (when (and
                 (jsown:keyp ast "kind") (= (jsown:val ast "kind") *method-declaration*)
                 (jsown:keyp ast "start") (<= (jsown:val ast "start") ast-pos)
                 (jsown:keyp ast "end") (> (jsown:val ast "end") ast-pos))
-          (return (convert-to-pos (parser-path parser) file-path
-                                  (jsown:val (cdr (jsown:val ast "name")) "escapedText")
-                                  (jsown:val ast "start"))))
+          (when (jsown:keyp ast "name")
+            (let ((name (cdr (jsown:val ast "name"))))
+              (return (convert-to-pos (parser-path parser) file-path
+                                      (jsown:val name "escapedText")
+                                      (jsown:val name "start"))))))
 
         (when (and
                 (jsown:keyp ast "kind")

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -57,7 +57,7 @@
   (let ((ctx (inga/main::start *back-path* '(:java) '("src/test/**"))))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
-             (:name . "getArticles") (:line . 48) (:offset . 3)))
+             (:name . "getArticles") (:line . 49) (:offset . 25)))
           (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
                   (inga/main::analyze-by-range
                     ctx
@@ -69,9 +69,9 @@
   (let ((ctx (inga/main::start *back-path* '(:java) '("src/test/**"))))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
-             (:name . "createArticle") (:line . 28) (:offset . 3))
+             (:name . "createArticle") (:line . 29) (:offset . 25))
             ((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
-             (:name . "createArticle") (:line . 35) (:offset . 3)))
+             (:name . "createArticle") (:line . 36) (:offset . 44)))
           (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
                   (inga/main::analyze-by-range
                     ctx
@@ -83,13 +83,13 @@
   (let ((ctx (inga/main::start *back-path* '(:java) '("src/test/**"))))
     (is (equal
           '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
-             (:name . "createArticle") (:line . 28) (:offset . 3))
+             (:name . "createArticle") (:line . 29) (:offset . 25))
             ((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
-             (:name . "createArticle") (:line . 35) (:offset . 3))
+             (:name . "createArticle") (:line . 36) (:offset . 44))
             ((:path . "src/main/java/io/spring/api/ArticleApi.java")
-             (:name . "updateArticle") (:line . 44) (:offset . 3))
+             (:name . "updateArticle") (:line . 45) (:offset . 28))
             ((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
-             (:name . "updateArticle") (:line . 53) (:offset . 3)))
+             (:name . "updateArticle") (:line . 54) (:offset . 44)))
           (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
                   (inga/main::analyze-by-range
                     ctx
@@ -101,11 +101,11 @@
   (let ((ctx (inga/main::start *back-path* '(:java) '("src/test/**"))))
     (is (equal
           '(((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
-             (:name . "createArticle") (:line . 35) (:offset . 3))
+             (:name . "createArticle") (:line . 36) (:offset . 44))
             ((:path . "src/main/java/io/spring/api/ArticlesApi.java")
-             (:name . "createArticle") (:line . 28) (:offset . 3))
+             (:name . "createArticle") (:line . 29) (:offset . 25))
             ((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
-             (:name . "createArticle") (:line . 35) (:offset . 3)))
+             (:name . "createArticle") (:line . 36) (:offset . 44)))
           (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
                   (inga/main::analyze-by-range
                     ctx
@@ -117,7 +117,7 @@
   (let ((ctx (inga/main::start *nestjs-path* '(:typescript))))
     (is (equal
           '(((:path . "src/article/article.controller.ts")
-             (:name . "findAll") (:line . 21) (:offset . 3)))
+             (:name . "findAll") (:line . 24) (:offset . 9)))
           (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
                   (inga/main::analyze-by-range
                     ctx

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -43,7 +43,7 @@
     (start-parser parser)
     (is (equal
           '((:path . "src/article/article.service.ts")
-            (:name . "findAll") (:line . 45) (:offset . 3))
+            (:name . "findAll") (:line . 45) (:offset . 9))
           (let ((src-path "src/article/article.service.ts"))
             (inga/parser/typescript::find-affected-pos
               parser


### PR DESCRIPTION
Changed to get the position of the name since getting the reference at the beginning of the function definition results in an unexpectedly wide range.