### PR TITLE
Support for searching ConstraintValidator references

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -186,7 +186,7 @@
                                     (find-affected-pos (context-parser ctx)
                                                        src-path ast line-no)))
                               (when item-pos
-                                (log-debug (format nil "affected-pos: ~a, src-path: ~a, line-no: ~a" item-pos src-path line-no))
+                                (log-debug (format nil "found-affected-pos: [src-path: ~a, line-no: ~a]~% -> ~a, " src-path line-no item-pos))
                                 (setf item-pos (acons :line-no line-no item-pos))
                                 (when (assoc :origin range)
                                   (setf item-pos (acons :origin (cdr (assoc :origin range)) item-pos)))
@@ -238,7 +238,7 @@
                                                                (context-exclude ctx))
                                        ref))
                                    refs)))
-    (log-debug (format nil "references: ~a, pos: ~a" refs pos))
+    (log-debug (format nil "found-references: [pos: ~a]~% -> ~a, " pos refs))
     (if refs
         (loop for ref in refs
               do (progn 

--- a/test/main.lisp
+++ b/test/main.lisp
@@ -59,6 +59,22 @@
                       (:start . 105) (:end . 105))))))
     (inga/main::stop ctx)))
 
+(test analyze-by-range-for-constraint-validator
+  (let ((ctx (inga/main::start *back-path* '(:java) '("src/test/**"))))
+    (is (equal
+          '(((:path . "src/main/java/io/spring/api/ArticlesApi.java")
+             (:name . "createArticle") (:line . 29) (:offset . 25))
+            ((:path . "src/main/java/io/spring/graphql/ArticleMutation.java")
+             (:name . "createArticle") (:line . 36) (:offset . 44)))
+          (remove-duplicates
+            (mapcar (lambda (e) (cdr (assoc :entorypoint e)))
+                    (inga/main::analyze-by-range
+                      ctx
+                      '((:path . "src/main/java/io/spring/application/article/DuplicatedArticleValidator.java")
+                        (:start . 16) (:end . 16))))
+            :test #'equal)))
+    (inga/main::stop ctx)))
+
 (def-suite main)
 (in-suite main)
 

--- a/test/parser/java.lisp
+++ b/test/parser/java.lisp
@@ -67,6 +67,28 @@
               18))))
     (stop-parser parser)))
 
+;; class DuplicatedArticleValidator
+;;                                    ↓[out]
+;;     implements ConstraintValidator<DuplicatedArticleConstraint, String> {
+;;   @Override
+;;   public boolean isValid(String value, ConstraintValidatorContext context) {
+;;     return true; ←[in]
+;;   }
+;; }
+(test find-affected-pos-for-constraint-validator
+  (let ((parser (make-parser :java *spring-boot-path*)))
+    (start-parser parser)
+    (is (equal
+          '((:path . "src/main/java/io/spring/application/article/DuplicatedArticleValidator.java")
+            (:name . "DuplicatedArticleConstraint") (:line . 10) (:offset . 36))
+          (let ((src-path "src/main/java/io/spring/application/article/DuplicatedArticleValidator.java"))
+            (find-affected-pos
+              parser
+              src-path
+              (exec-parser parser src-path)
+              16))))
+    (stop-parser parser)))
+
 ;; public class Article {
 ;;   public void update(String title, String description, String body) {
 ;;   } ←[in]


### PR DESCRIPTION
`ConstraintValidator.isValid` does not directly reference a method, so it searches for the annotated location.