### PR TITLE
Rename to base-commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ Code changes daily, and it is always important to check the impact of changes.
 In many cases, checking the impact of a change depends on how vigilant the author is in writing the code, making it difficult to detect unintended effects during the code review and QA phases.
 This tool improves software quality by detecting unintended changes at an early phase.
 
-## Supported languages
+## Quick Start
 
-- Java
-- TypeScript
+Run in the Docker container:
+
+### Java
+
+```sh
+docker run --rm -v $PWD:/work ghcr.io/seachicken/inga:latest-java --root-path /work --base-commit main
+```
+
+### TypeScript
+
+```sh
+docker run --rm -v $PWD:/work ghcr.io/seachicken/inga:latest-typescript --root-path /work --base-commit main
+```
 
 ## Usage
 
@@ -38,9 +49,9 @@ Filenames to exclude from the analysis.
 
 If GitHub token is set, send the analysis report to comments in pull requests. Analyze with diffs of base and head branch of pull requests.
 
-`--base-sha <string>`
+`--base-commit <string>`
 
-Analyze by the difference between the `base-sha` and the checked out sha. Not to be used with `--github-token` option.
+Analyze the difference between the base-commit and the checked-out commit. Set refname or SHA. If the github-token option is used, this option will be ignored and set automatically.
 
 `--min-combination <number>`
 

--- a/git.lisp
+++ b/git.lisp
@@ -6,9 +6,9 @@
            #:track-branch))
 (in-package #:inga/git)
 
-(defun get-diff (project-path base-sha)
+(defun get-diff (project-path base-commit)
   (let ((diff (uiop:run-program
-                (format nil "(cd ~a && git diff ~a --unified=0 --)" project-path base-sha)
+                (format nil "(cd ~a && git diff ~a --unified=0 --)" project-path base-commit)
                 :output :string)))
 
     (let ((ranges (make-array 10 :fill-pointer 0 :adjustable t)) to-path)

--- a/main.lisp
+++ b/main.lisp
@@ -42,17 +42,17 @@
 
 (defun command (&rest argv)
   (handler-case
-    (destructuring-bind (&key root-path exclude github-token base-sha min-combination) (parse-argv argv)
+    (destructuring-bind (&key root-path exclude github-token base-commit min-combination) (parse-argv argv)
       (let (diffs pr hostname)
         (when github-token
           (setf hostname (inga/git:get-hostname root-path))
           (inga/github:login hostname github-token)
           (setf pr (inga/github:get-pr root-path))
           (destructuring-bind (&key base-url owner-repo number base-ref-name head-sha) pr
-            (unless base-sha
+            (unless base-commit
               (inga/git:track-branch base-ref-name root-path)
-              (setf base-sha base-ref-name))))
-        (setf diffs (get-diff root-path base-sha))
+              (setf base-commit base-ref-name))))
+        (setf diffs (get-diff root-path base-commit))
 
         (let ((ctx (start root-path
                           (filter-active-context (get-analysis-kinds diffs) (get-env-kinds))
@@ -69,7 +69,7 @@
   (loop with root-path = "."
         with exclude = '()
         with github-token = nil
-        with base-sha = nil
+        with base-commit = nil
         with min-combination = 3
         for option = (pop argv)
         while option
@@ -84,8 +84,8 @@
               (setf exclude (split-trim-comma (pop argv))))
              ("--github-token"
               (setf github-token (pop argv)))
-             ("--base-sha"
-              (setf base-sha (pop argv)))
+             ("--base-commit"
+              (setf base-commit (pop argv)))
              ("--min-combination"
               (setf min-combination (parse-integer (pop argv))))
              (t (error 'inga-error-option-not-found)))
@@ -95,8 +95,8 @@
                     (list :exclude exclude)
                     (when github-token
                       (list :github-token github-token))
-                    (when base-sha
-                      (list :base-sha base-sha))
+                    (when base-commit
+                      (list :base-commit base-commit))
                     (list :min-combination min-combination)))))
 
 (defun start (root-path context-kinds &optional (exclude '()))


### PR DESCRIPTION
Rename the option name since the option can set it to something other than SHA.