### PR TITLE
Remove display of number of combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ If GitHub token is set, send the analysis report to comments in pull requests. A
 
 Analyze the difference between the --base-commit and the checked-out commit. Set refname or SHA. If the --github-token option is used, this option will be ignored and set automatically.
 
-`--min-combination <number>`
-
-Minimum number of combinations to display in the results.
-
 ### Run on GitHub Actions
 
 #### Example projects

--- a/parser/base.lisp
+++ b/parser/base.lisp
@@ -8,7 +8,6 @@
            #:stop-parser
            #:exec-parser
            #:find-affected-pos
-           #:count-combinations
            #:find-entrypoint
            #:exec-command))
 (in-package #:inga/parser/base)
@@ -30,8 +29,6 @@
 (defgeneric exec-parser (parser file-path))
 
 (defgeneric find-affected-pos (parser file-path ast line-no))
-
-(defgeneric count-combinations (parser file-path ast line-nos))
 
 (defgeneric find-entrypoint (parser pos))
 

--- a/parser/java.lisp
+++ b/parser/java.lisp
@@ -99,46 +99,5 @@
           (loop for member in (jsown:val ast "members") do
                 (enqueue q (cdr member))))))))
 
-(defmethod count-combinations ((parser parser-java) file-path ast line-nos)
-  (loop
-    with found-items = '()
-    with result = 1
-    for line-no in line-nos do
-    (let ((q (make-queue)))
-      (enqueue q ast)
-      (loop
-        (let ((ast (dequeue q)))
-          (if (null ast) (return))
-
-          (when (and
-                  (string= (cdr (car ast)) "com.github.javaparser.ast.stmt.IfStmt")
-                  (<= (jsown:val (jsown:val ast "range") "beginLine") line-no)
-                  (>= (jsown:val (jsown:val ast "range") "endLine") line-no)
-                  (null (assoc (jsown:val (jsown:val ast "range") "beginLine") found-items)))
-            (push (cons (jsown:val (jsown:val ast "range") "beginLine") t) found-items)
-            (setf result (* result 2)))
-
-          (when (and
-                  (or
-                    (string= (cdr (car ast)) "com.github.javaparser.ast.body.ConstructorDeclaration")
-                    (string= (cdr (car ast)) "com.github.javaparser.ast.body.MethodDeclaration"))
-                  (<= (jsown:val (jsown:val ast "range") "beginLine") line-no)
-                  (>= (jsown:val (jsown:val ast "range") "endLine") line-no)
-                  (when (jsown:keyp ast "body")
-                    (enqueue q (cdr (jsown:val ast "body"))))))
-
-          (when (jsown:keyp ast "types")
-            (loop for type in (jsown:val ast "types") do
-                  (enqueue q (cdr type))))
-
-          (when (jsown:keyp ast "members")
-            (loop for member in (jsown:val ast "members") do
-                  (enqueue q (cdr member))))
-
-          (when (jsown:keyp ast "statements")
-            (loop for s in (jsown:val ast "statements") do
-                  (enqueue q (cdr s)))))))
-    finally (return result)))
-
 (defmethod find-entrypoint ((parser parser-java) pos))
 

--- a/test/github.lisp
+++ b/test/github.lisp
@@ -7,37 +7,12 @@
 (def-suite github)
 (in-suite github)
 
-(test get-combination-table
-  (is (equal (format nil "~a~%~a~%~a~%~a~%~a~%"
-                     "| Rank | Changed Functions | Combinations |"
-                     "| - | - | - |"
-                     "| 1 | [1.ts - b](https://github.com/owner/repo/blob/sha/a/1.ts#L1) | 3 💥 |"
-                     "| 1 | [1.ts - a](https://github.com/owner/repo/blob/sha/a/1.ts#L1) | 3 💥 |"
-                     "| 2 | [1.ts - d](https://github.com/owner/repo/blob/sha/a/1.ts#L1) | 2 |")
-             (inga/github::get-combination-table
-               "https://github.com/owner/repo/" "sha"
-               (inga/github::filter-combinations
-                 (inga/github::filter-by-key
-                   (inga/github::sort-by-combination
-                     '(((:origin (:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 3))
-                        (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))
-                       ((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
-                        (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))
-                       ((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
-                        (:entorypoint (:path . "b/a/1.tsx") (:name . "b") (:line . 1)))
-                       ((:origin (:path . "a/1.ts") (:name . "c") (:line . 1) (:combination . 1))
-                        (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))
-                       ((:origin (:path . "a/1.ts") (:name . "d") (:line . 1) (:combination . 2))
-                        (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))))
-                   :origin)
-                 2)))))
-
 (test get-code-hierarchy
   (is (equal (format nil "~a~%~a~%~a~%~a~%~a~%~a~%~a~%~a~%"
                      "- 📂 b"
                      "  - 📂 a"
                      "    - 📄 [1.tsx - a](https://github.com/owner/repo/blob/sha/b/a/1.tsx#L1)"
-                     "    - 📄 [1.tsx - b 💥](https://github.com/owner/repo/blob/sha/b/a/1.tsx#L2)"
+                     "    - 📄 [1.tsx - b](https://github.com/owner/repo/blob/sha/b/a/1.tsx#L2)"
                      "  - 📄 [1.tsx - a](https://github.com/owner/repo/blob/sha/b/1.tsx#L1)"
                      "- 📂 c/a"
                      "  - 📄 [1.tsx - a](https://github.com/owner/repo/blob/sha/c/a/1.tsx#L3)"
@@ -45,41 +20,38 @@
              (inga/github::get-code-hierarchy
                "https://github.com/owner/repo/" "sha"
                (inga/github::group-by-entorypoint
-                 '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
+                 '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1))
                     (:entorypoint (:path . "b/a/1.tsx") (:name . "b") (:line . 2)))
-                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 2) (:combination . 2))
+                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 2))
                     (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))
-                   ((:origin (:path . "a/1.ts") (:name . "c") (:line . 3) (:combination . 2))
+                   ((:origin (:path . "a/1.ts") (:name . "c") (:line . 3))
                     (:entorypoint (:path . "b/a/1.tsx") (:name . "b") (:line . 2)))
-                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 2) (:combination . 2))
+                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 2))
                     (:entorypoint (:path . "b/1.tsx") (:name . "a") (:line . 1)))
-                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 2))
+                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1))
                     (:entorypoint (:path . "c/a/1.tsx") (:name . "a") (:line . 3)))
-                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 2))
-                    (:entorypoint (:path . "a.tsx") (:name . "a") (:line . 4)))))
-               '(((:rank . 1)
-                  (:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
-                  (:entorypoint (:path . "b/a/1.tsx") (:name . "b") (:line . 2))))))))
+                   ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1))
+                    (:entorypoint (:path . "a.tsx") (:name . "a") (:line . 4)))))))))
 
 (test group-by-entorypoint
   (is (equal
         '(((:entorypoint (:path . "b/a/1.ts") (:name . "a") (:line . 1))
-           (:origins (((:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
-                      ((:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 2))))))
+           (:origins (((:path . "a/1.ts") (:name . "a") (:line . 1))
+                      ((:path . "a/1.ts") (:name . "b") (:line . 1))))))
         (inga/github::group-by-entorypoint
-          '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
+          '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1))
              (:entorypoint (:path . "b/a/1.ts") (:name . "a") (:line . 1)))
-            ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 2))
+            ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1))
              (:entorypoint (:path . "b/a/1.ts") (:name . "a") (:line . 1))))))))
 
 (test filter-by-key
   (is (equal
-        '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
+        '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1))
            (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1))))
         (inga/github::filter-by-key
-          '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1) (:combination . 3))
+          '(((:origin (:path . "a/1.ts") (:name . "a") (:line . 1))
              (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1)))
-            ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1) (:combination . 2))
+            ((:origin (:path . "a/1.ts") (:name . "b") (:line . 1))
              (:entorypoint (:path . "b/a/1.tsx") (:name . "a") (:line . 1))))
           :entorypoint))))
 

--- a/test/parser/java.lisp
+++ b/test/parser/java.lisp
@@ -106,16 +106,3 @@
               65))))
     (stop-parser parser)))
 
-(test count-combinations
-  (let ((parser (make-parser :java *spring-boot-path*)))
-    (start-parser parser)
-    (is (equal
-          2
-          (let ((src-path "src/main/java/io/spring/core/article/Article.java"))
-            (inga/parser/typescript::count-combinations
-              parser
-              src-path
-              (exec-parser parser src-path)
-              '(53 54)))))
-    (stop-parser parser)))
-

--- a/test/parser/typescript.lisp
+++ b/test/parser/typescript.lisp
@@ -124,19 +124,6 @@
               150))))
     (stop-parser parser)))
 
-(test count-combinations
-  (let ((parser (make-parser :typescript *nestjs-path*)))
-    (start-parser parser)
-    (is (equal
-          2
-          (let ((src-path "src/article/article.service.ts"))
-            (inga/parser/typescript::count-combinations
-              parser
-              src-path
-              (exec-parser parser src-path)
-              '(69 70)))))
-    (stop-parser parser)))
-
 (test find-entrypoint
   (let ((parser (make-parser :typescript *react-path*)))
     (start-parser parser)


### PR DESCRIPTION
Since this tool is designed to check for unexpected changes, there is little point in having a highlighting file gazed at, so remove it.