### PR TITLE
Exclude `java` file name from analysis

### DIFF
--- a/file.lisp
+++ b/file.lisp
@@ -23,5 +23,9 @@
 
 (defun to-scan-str (str)
   (format nil "^~a$"
-          (ppcre:regex-replace-all "\\*" str ".+")))
+          (ppcre:regex-replace-all
+            "\\*"
+            ;; replace from "." with escaped dot "\."
+            (ppcre:regex-replace-all "\\." str "\\.")
+            ".+")))
 

--- a/test/file.lisp
+++ b/test/file.lisp
@@ -50,6 +50,11 @@
         t
         (is-analysis-target "src/index.js" '("*.js")))))
 
+(test not-analyze-when-the-file-name-is-the-same-extension
+  (is (equal
+        nil
+        (is-analysis-target "src/js" '("*.js")))))
+
 (test not-analyze-when-not-include
   (is (equal
         nil


### PR DESCRIPTION
If `bin/java` is included in the repository, it will try to parse it as text, which will result in an error, so exclude it if it is not an extension.