### PR TITLE
Get local change diff by default

### DIFF
--- a/git.lisp
+++ b/git.lisp
@@ -8,7 +8,9 @@
 
 (defun get-diff (project-path base-commit)
   (let ((diff (uiop:run-program
-                (format nil "(cd ~a && git diff ~a --unified=0 --)" project-path base-commit)
+                (format nil "(cd ~a && git diff ~a --unified=0 --)"
+                        project-path
+                        (if base-commit base-commit ""))
                 :output :string)))
     (let ((ranges (make-array 10 :fill-pointer 0 :adjustable t)) to-path)
       (with-input-from-string (in diff)


### PR DESCRIPTION
Inga is currently running on the IDE; if the base branch option is not set, the default behavior is getting diff by local changes, which makes the user easier to use.