### PR TITLE
Create a message queue for the language server

### DIFF
--- a/language-client/base.lisp
+++ b/language-client/base.lisp
@@ -77,5 +77,5 @@
       finally (return (flexi-streams:octets-to-string buff :external-format :utf-8)))))
 
 (defun get-references-key (pos)
-  (intern (format nil "refs-~a-~a" (cdr (assoc :path pos)) (cdr (assoc :top-offset pos)))))
+  (intern (format nil "refs-~a-~a" (cdr (assoc :path pos)) (cdr (assoc :top-offset pos))) :keyword))
 

--- a/test/language-server.lisp
+++ b/test/language-server.lisp
@@ -1,0 +1,33 @@
+(defpackage #:inga/test/language-server
+  (:use #:cl
+        #:fiveam
+        #:inga/language-server))
+(in-package #:inga/test/language-server)
+
+(def-suite language-server)
+(in-suite language-server)
+
+(test dequeue-msg
+  (inga/language-server::init-msg-q)
+  (inga/language-server::enqueue-msg '(:obj ("id" . "1") ("method" . "textDocument/didOpen")))
+  (inga/language-server::enqueue-msg '(:obj ("id" . "2") ("method" . "textDocument/didChange")))
+  (is (equal
+        '(:obj ("id" . "1") ("method" . "textDocument/didOpen"))
+        (inga/language-server::dequeue-msg))))
+
+(test keep-last-one-when-multiple-didchange-events-are-received
+  (inga/language-server::init-msg-q)
+  (inga/language-server::enqueue-msg '(:obj ("id" . "1") ("method" . "textDocument/didChange")))
+  (inga/language-server::enqueue-msg '(:obj ("id" . "2") ("method" . "textDocument/didChange")))
+  (is (equal
+        '(:obj ("id" . "2") ("method" . "textDocument/didChange"))
+        (inga/language-server::dequeue-msg))))
+
+(test discard-queue-when-shutdown-event-is-received
+  (inga/language-server::init-msg-q)
+  (inga/language-server::enqueue-msg '(:obj ("id" . "1") ("method" . "textDocument/didChange")))
+  (inga/language-server::enqueue-msg '(:obj ("id" . "2") ("method" . "shutdown")))
+  (is (equal
+        '(:obj ("id" . "2") ("method" . "shutdown"))
+        (inga/language-server::dequeue-msg))))
+

--- a/traversal/base.lisp
+++ b/traversal/base.lisp
@@ -293,10 +293,12 @@
                       (cdr (assoc :type pos))
                       (cdr (assoc :host pos))
                       (cdr (assoc :name pos))
-                      (cdr (assoc :path pos))))
+                      (cdr (assoc :path pos)))
+              :keyword)
       (intern (format nil "refs-~a-~a"
                       (cdr (assoc :path pos))
-                      (cdr (assoc :top-offset pos))))))
+                      (cdr (assoc :top-offset pos)))
+              :keyword)))
 
 (defun get-traversal (path)
   (let ((result (cdr (assoc (get-file-type path) *traversals*))))

--- a/traversal/java.lisp
+++ b/traversal/java.lisp
@@ -66,14 +66,14 @@
     (unless ast (return))
 
     (when (equal (ast-value ast "type") "PACKAGE")
-      (return-from find-package-index-key (intern (ast-value ast "packageName"))))
+      (return-from find-package-index-key (intern (ast-value ast "packageName") :keyword)))
 
     (loop for child in (jsown:val ast "children")
           do (setf stack (append stack (list child))))))
 
 (defun find-project-index-key (path)
   (let ((base-path (find-base-path path)))
-    (when base-path (intern (namestring base-path)))))
+    (when base-path (intern (namestring base-path) :keyword))))
 
 (defmethod get-scoped-index-paths-generic ((traversal traversal-java) pos)
   (cond

--- a/traversal/kotlin.lisp
+++ b/traversal/kotlin.lisp
@@ -67,13 +67,14 @@
       (return-from find-package-index-key
                    (intern (format nil "~{~a~^.~}"
                                    (get-dot-expressions
-                                     (first (get-asts ast '("PACKAGE_DIRECTIVE" "*"))))))))
+                                     (first (get-asts ast '("PACKAGE_DIRECTIVE" "*")))))
+                           :keyword)))
 
     (loop for child in (jsown:val ast "children") do (enqueue q child))))
 
 (defun find-project-index-key (path)
   (let ((base-path (find-base-path path)))
-    (when base-path (intern (namestring base-path)))))
+    (when base-path (intern (namestring base-path) :keyword))))
 
 (defmethod get-scoped-index-paths-generic ((trav traversal-kotlin) pos)
   (cond
@@ -352,7 +353,7 @@
                                                                     class-name))
                                                            (mapcan (lambda (fqcn)
                                                                      (loop for path in (gethash (intern 
-                                                                                                  (get-package-name fqcn))
+                                                                                                  (get-package-name fqcn) :keyword)
                                                                                                 (gethash :package *file-index*))
                                                                            do
                                                                            (let ((s (load-structure fqcn path)))

--- a/utils.lisp
+++ b/utils.lisp
@@ -5,6 +5,9 @@
   (:export #:make-queue
            #:enqueue
            #:dequeue
+           #:dequeue-last
+           #:peek
+           #:peek-last
            #:split
            #:split-trim-comma
            #:funtime))
@@ -21,6 +24,20 @@
 (defun dequeue (q)
   (unless (null (queue-values q))
     (pop (queue-values q))))
+
+(defun dequeue-last (q)
+  (unless (null (queue-values q))
+    (let ((last (last (queue-values q))))
+      (setf (queue-values q) (butlast (queue-values q)))
+      last)))
+
+(defun peek (q)
+  (unless (null (queue-values q))
+    (first (queue-values q))))
+
+(defun peek-last (q)
+  (unless (null (queue-values q))
+    (first (last (queue-values q)))))
 
 (defun split (div sequence)
   (let ((pos (position div sequence)))


### PR DESCRIPTION
Every time code is edited, events such as `didChange` events are sent from the language client and cannot be analyzed in time, so events are queued, and only necessary requests are processed.