### PR TITLE
Do not index targets of .gitignore

### DIFF
--- a/ast-index/disk.lisp
+++ b/ast-index/disk.lisp
@@ -8,6 +8,8 @@
                 #:stop-all-parsers)
   (:import-from #:inga/file
                 #:is-analysis-target)
+  (:import-from #:inga/git
+                #:is-ignore)
   (:import-from #:inga/errors
                 #:inga-error)
   (:export #:ast-index-disk))
@@ -28,7 +30,8 @@
         do
         (let ((relative-path (enough-namestring path (ast-index-root-path ast-index))))
           (when (and (is-analysis-target ctx-kind relative-path include exclude)
-                     (is-analysis-target ctx-kind relative-path include-files exclude))
+                     (is-analysis-target ctx-kind relative-path include-files exclude)
+                     (not (is-ignore (ast-index-root-path ast-index) relative-path)))
             (setf (ast-index-paths ast-index)
                   (append (ast-index-paths ast-index) (list relative-path)))
             (update-index ast-index relative-path)))))

--- a/ast-index/memory.lisp
+++ b/ast-index/memory.lisp
@@ -7,6 +7,8 @@
                 #:stop-all-parsers)
   (:import-from #:inga/file
                 #:is-analysis-target)
+  (:import-from #:inga/git
+                #:is-ignore)
   (:export #:ast-index-memory))
 (in-package #:inga/ast-index/memory)
 
@@ -18,7 +20,8 @@
         do
         (let ((relative-path (enough-namestring path (ast-index-root-path ast-index))))
           (when (and (is-analysis-target ctx-kind relative-path include exclude)
-                     (is-analysis-target ctx-kind relative-path include-files exclude))
+                     (is-analysis-target ctx-kind relative-path include-files exclude)
+                     (not (is-ignore (ast-index-root-path ast-index) relative-path)))
             (setf (ast-index-paths ast-index)
                   (append (ast-index-paths ast-index) (list relative-path)))))))
 

--- a/git.lisp
+++ b/git.lisp
@@ -3,7 +3,8 @@
   (:import-from #:cl-ppcre)
   (:import-from #:inga/errors
                 #:inga-error)
-  (:export #:get-diff))
+  (:export #:get-diff
+           #:is-ignore))
 (in-package #:inga/git)
 
 (defun get-diff (project-path base-commit)
@@ -34,4 +35,11 @@
                                                   (cons :end end))
                                             ranges))))))))
       (return-from get-diff (coerce ranges 'list)))))
+
+(defun is-ignore (project-path relative-path)
+  (multiple-value-bind (output error-output exit-code)
+    (uiop:run-program
+      (format nil "(cd ~a && git check-ignore ~a)" project-path relative-path)
+      :ignore-error-status t)
+    (eq exit-code 0)))
 


### PR DESCRIPTION
Indexing generated code such as the build directory can take a long time to analyze, so .gitignore files are automatically excluded from analysis.