### PR TITLE
Change ast-index to hash name

### DIFF
--- a/ast-index/base.lisp
+++ b/ast-index/base.lisp
@@ -8,6 +8,7 @@
            #:ast-scoped-paths
            #:create-indexes
            #:update-index
+           #:stop-indexes
            #:clean-indexes
            #:get-ast
            #:attach-parent))
@@ -27,6 +28,8 @@
 (defgeneric create-indexes (ast-index ctx-kind include include-files exclude))
 
 (defgeneric update-index (ast-index path))
+
+(defgeneric stop-indexes (ast-index))
 
 (defgeneric clean-indexes (ast-index))
 

--- a/ast-index/disk.lisp
+++ b/ast-index/disk.lisp
@@ -20,13 +20,24 @@
 (defclass ast-index-disk (ast-index)
   ((index-path
      :initarg :temp-path
-     :accessor ast-index-disk-path)))
+     :accessor ast-index-disk-path)
+   (src-hash
+     :initform (make-hash-table)
+     :reader ast-index-src-hash)))
 
 (defmethod initialize-instance :after ((ast-index ast-index-disk)
                                        &key (temp-path (merge-pathnames ".inga/")))
   (setf (slot-value ast-index 'index-path) (merge-pathnames "index/" temp-path)))
 
 (defmethod create-indexes ((ast-index ast-index-disk) ctx-kind include include-files exclude)
+  (when (probe-file (merge-pathnames "src-hash.json" (ast-index-disk-path ast-index)))
+    (let ((src-hash (jsown:parse (alexandria:read-file-into-string
+                                   (merge-pathnames "src-hash.json"
+                                                    (ast-index-disk-path ast-index))))))
+      (loop for hash in (cdr src-hash)
+            do
+            (setf (gethash (intern (car hash) :keyword) (ast-index-src-hash ast-index)) (cdr hash)))))
+
   (ensure-directories-exist (ast-index-disk-path ast-index)) 
   (loop for path in (uiop:directory-files (format nil "~a/**/*" (ast-index-root-path ast-index)))
         with index-exclude-path = (concatenate 'string (enough-namestring
@@ -39,19 +50,33 @@
                      (not (is-ignore (ast-index-root-path ast-index) relative-path)))
             (setf (ast-index-paths ast-index)
                   (append (ast-index-paths ast-index) (list relative-path)))
-            (update-index ast-index relative-path)))))
+            (update-index ast-index relative-path))))
+  (commit-src-hash ast-index))
 
 (defmethod update-index ((ast-index ast-index-disk) path)
-  (log-info (format nil "upsert ast-index at ~a" path))
-  (with-open-file (out (get-index-path path (ast-index-disk-path ast-index))
-                       :direction :output
-                       :if-exists :supersede
-                       :if-does-not-exist :create)
-    (format out "~a" (format nil "~a" (parse (merge-pathnames
-                                               path (ast-index-root-path ast-index)))))))
+  (let* ((src (alexandria:read-file-into-string (merge-pathnames
+                                                  path (ast-index-root-path ast-index))))
+         (src-hash (sxhash src)))
+    (when (eq src-hash
+              (gethash (intern (get-hash-path path) :keyword) (ast-index-src-hash ast-index)))
+      (return-from update-index))
+
+    (log-info (format nil "upsert ast-index at ~a" path))
+    (with-open-file (out (get-index-path path (ast-index-disk-path ast-index))
+                         :direction :output
+                         :if-exists :supersede
+                         :if-does-not-exist :create)
+      (format out "~a" (format nil "~a" (parse (merge-pathnames
+                                                 path (ast-index-root-path ast-index)))))
+      (setf (gethash (intern (get-hash-path path) :keyword) (ast-index-src-hash ast-index))
+            src-hash))))
+
+(defmethod stop-indexes ((ast-index ast-index-disk))
+  (stop-all-parsers)
+  (commit-src-hash ast-index))
 
 (defmethod clean-indexes ((ast-index ast-index-disk))
-  (stop-all-parsers)
+  (stop-indexes ast-index)
   (uiop:delete-directory-tree (ast-index-disk-path ast-index)
                               :validate t
                               :if-does-not-exist :ignore))
@@ -61,8 +86,18 @@
     (jsown:parse (alexandria:read-file-into-string
                    (get-index-path path (ast-index-disk-path ast-index))))))
 
+(defun commit-src-hash (ast-index)
+  (with-open-file (out (merge-pathnames "src-hash.json" (ast-index-disk-path ast-index))
+                       :direction :output
+                       :if-exists :supersede
+                       :if-does-not-exist :create)
+    (format out "~a" (jsown:to-json (ast-index-src-hash ast-index)))))
+
 (defun get-index-path (original-path index-path)
   (merge-pathnames
     index-path
-    (ppcre:regex-replace-all "/" original-path "--")))
+    (get-hash-path original-path)))
+
+(defun get-hash-path (path)
+  (princ-to-string (sxhash path)))
 

--- a/ast-index/memory.lisp
+++ b/ast-index/memory.lisp
@@ -27,8 +27,11 @@
 
 (defmethod update-index ((ast-index ast-index-memory) path))
 
-(defmethod clean-indexes ((ast-index ast-index-memory))
+(defmethod stop-indexes ((ast-index ast-index-memory))
   (stop-all-parsers))
+
+(defmethod clean-indexes ((ast-index ast-index-memory))
+  (stop-indexes ast-index))
 
 (defmethod get-ast (ast-index path)
   (attach-parent (jsown:parse (parse (merge-pathnames path (ast-index-root-path ast-index))))))

--- a/test/ast-index/disk.lisp
+++ b/test/ast-index/disk.lisp
@@ -16,6 +16,22 @@
             (ast-index-paths index))))
     (clean-indexes index)))
 
+(test update-index-when-file-changed
+  (let ((index (make-instance 'ast-index-disk :root-path *java-path*))
+        (path "src/main/java/p1/ConstructorDefinition.java"))
+    (create-indexes index :java nil '("*.java") nil)
+    (let ((create-sec (sb-posix:stat-mtime
+                        (sb-posix:stat
+                          (inga/ast-index/disk::get-index-path
+                            path (inga/ast-index/disk::ast-index-disk-path index))))))
+      (update-index index path)
+      (is (eq (sb-posix:stat-mtime
+                (sb-posix:stat
+                  (inga/ast-index/disk::get-index-path
+                    path (inga/ast-index/disk::ast-index-disk-path index))))
+              create-sec)))
+    (clean-indexes index)))
+
 (test get-all-paths
   (let ((index (make-instance 'ast-index-disk
                               :root-path *java-path*)))

--- a/traversal/java.lisp
+++ b/traversal/java.lisp
@@ -7,9 +7,9 @@
   (:import-from #:inga/ast-index
                 #:ast-index-paths
                 #:ast-index-root-path
-                #:clean-indexes
                 #:create-indexes
-                #:get-ast)
+                #:get-ast
+                #:stop-indexes)
   (:import-from #:inga/traversal/kotlin
                 #:traversal-kotlin)
   (:import-from #:inga/file
@@ -39,7 +39,7 @@
   (cdr (assoc :java *traversals*)))
 
 (defmethod stop-traversal ((traversal traversal-java))
-  (clean-indexes (traversal-index traversal))
+  (stop-indexes (traversal-index traversal))
   (setf *traversals* nil))
 
 (defun create-index-groups (traversal)

--- a/traversal/kotlin.lisp
+++ b/traversal/kotlin.lisp
@@ -5,9 +5,9 @@
   (:import-from #:inga/ast-index
                 #:ast-index-paths
                 #:ast-index-root-path
-                #:clean-indexes
                 #:create-indexes
-                #:get-ast)
+                #:get-ast
+                #:stop-indexes)
   (:import-from #:inga/file
                 #:get-file-type)
   (:import-from #:inga/logger
@@ -36,7 +36,7 @@
   (cdr (assoc :kotlin *traversals*)))
 
 (defmethod stop-traversal ((traversal traversal-kotlin))
-  (clean-indexes (traversal-index traversal))
+  (stop-indexes (traversal-index traversal))
   (setf *traversals* nil))
 
 (defun create-index-groups (traversal)

--- a/traversal/typescript.lisp
+++ b/traversal/typescript.lisp
@@ -3,9 +3,9 @@
         #:inga/traversal/base
         #:inga/utils)
   (:import-from #:inga/ast-index
-                #:clean-indexes
                 #:create-indexes
-                #:get-ast)
+                #:get-ast
+                #:stop-indexes)
   (:export #:traversal-typescript))
 (in-package #:inga/traversal/typescript)
 
@@ -24,7 +24,7 @@
   (cdr (assoc :typescript *traversals*)))
 
 (defmethod stop-traversal ((traversal traversal-typescript))
-  (clean-indexes (traversal-index traversal))
+  (stop-indexes (traversal-index traversal))
   (setf *traversals* nil))
 
 (defmethod find-definitions-generic ((traversal traversal-typescript) range)


### PR DESCRIPTION
- Fixed an issue where an error would occur if the index file name exceeded 255
- Do not update the index if there are no changes to the file