### PR TITLE
Add parser version to src hash

### DIFF
--- a/ast-index/disk.lisp
+++ b/ast-index/disk.lisp
@@ -5,7 +5,8 @@
   (:import-from #:jsown)
   (:import-from #:inga/ast-parser
                 #:parse
-                #:stop-all-parsers)
+                #:stop-all-parsers
+                #:version)
   (:import-from #:inga/file
                 #:is-analysis-target)
   (:import-from #:inga/git
@@ -53,9 +54,7 @@
   (commit-src-hash ast-index))
 
 (defmethod update-index ((ast-index ast-index-disk) path)
-  (let* ((src (alexandria:read-file-into-string (merge-pathnames
-                                                  path (ast-index-root-path ast-index))))
-         (src-hash (sxhash src)))
+  (let ((src-hash (get-hash-file-with-version path (ast-index-root-path ast-index))))
     (when (eq src-hash
               (gethash (intern (get-hash-path path) :keyword) (ast-index-src-hash ast-index)))
       (return-from update-index))
@@ -100,4 +99,8 @@
 
 (defun get-hash-path (path)
   (princ-to-string (sxhash path)))
+
+(defun get-hash-file-with-version (path root-path)
+  (let ((file (alexandria:read-file-into-string (merge-pathnames path root-path))))
+    (sxhash (concatenate 'string (version path) file))))
 

--- a/ast-parser/base.lisp
+++ b/ast-parser/base.lisp
@@ -9,6 +9,8 @@
            #:ast-parser-process
            #:start
            #:stop
+           #:version
+           #:version-generic
            #:stop-all-parsers
            #:parse))
 (in-package #:inga/ast-parser/base)
@@ -23,6 +25,10 @@
 (defgeneric start (file-type))
 
 (defgeneric stop (ast-parser))
+
+(defun version (path)
+  (version-generic (get-parser path)))
+(defgeneric version-generic (ast-parser))
 
 (defun stop-all-parsers ()
   (loop for p in *ast-parsers* do (stop (cdr p)))

--- a/ast-parser/java.lisp
+++ b/ast-parser/java.lisp
@@ -23,3 +23,6 @@
 (defmethod stop ((ast-parser ast-parser-java))
   (uiop:close-streams (ast-parser-process ast-parser)))
 
+(defmethod version-generic ((ast-parser ast-parser-java))
+  (uiop:getenv "JAVAPARSER"))
+

--- a/ast-parser/kotlin.lisp
+++ b/ast-parser/kotlin.lisp
@@ -19,3 +19,6 @@
 (defmethod stop ((ast-parser ast-parser-kotlin))
   (uiop:close-streams (ast-parser-process ast-parser)))
 
+(defmethod version-generic ((ast-parser ast-parser-kotlin))
+  (uiop:getenv "KTPARSRER"))
+

--- a/ast-parser/typescript.lisp
+++ b/ast-parser/typescript.lisp
@@ -17,3 +17,6 @@
 (defmethod stop ((ast-parser ast-parser-typescript))
   (uiop:close-streams (ast-parser-process ast-parser)))
 
+(defmethod version-generic ((ast-parser ast-parser-typescript))
+  (uiop:getenv "TSPARSRER"))
+

--- a/docker/typescript/Dockerfile
+++ b/docker/typescript/Dockerfile
@@ -8,6 +8,8 @@ RUN ros && \
 
 FROM node:18-slim
 
+ENV TSPARSER 0.1.1
+
 COPY --from=build /inga/roswell/inga /usr/local/bin/
 
 RUN apt-get update && \
@@ -15,7 +17,7 @@ RUN apt-get update && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g typescript @seachicken/tsparser
+RUN npm install -g typescript @seachicken/tsparser@$TSPARSER
 
 WORKDIR /work
 


### PR DESCRIPTION
Create a hash value including the AST parser version to rebuild the index when the AST index results change.