### PR TITLE
Improve performance for initialize

### DIFF
--- a/file.lisp
+++ b/file.lisp
@@ -7,15 +7,17 @@
 (in-package #:inga/file)
 
 (defparameter *include-typescript*
-  '("*.(js|jsx)"
-    "*.(ts|tsx)"))
+  '(".js"
+    ".jsx"
+    ".ts"
+    ".tsx"))
 (defparameter *include-java*
-  '("*.java"
-    "*.kt"))
+  '(".java"
+    ".kt"))
 
 (defun is-match (path ctx-kind)
   (loop for inc in (get-language-files ctx-kind)
-        do (when (ppcre:scan (to-scan-str inc) path)
+        do (when (uiop:string-suffix-p path inc)
              (return t))))
 
 (defun is-analysis-target (ctx-kind path &optional include exclude)
@@ -33,11 +35,11 @@
 (defun get-file-type (path)
   (let ((path (namestring path)))
     (cond
-      ((ppcre:scan (to-scan-str "*.java") path)
+      ((uiop:string-suffix-p path ".java")
        :java)
-      ((ppcre:scan (to-scan-str "*.kt") path)
+      ((uiop:string-suffix-p path ".kt")
        :kotlin)
-      ((ppcre:scan (to-scan-str "*.(js|jsx|ts|tsx)") path)
+      ((is-match path :typescript)
        :typescript))))
 
 (defun get-language-files (kind)


### PR DESCRIPTION
`file:is-match`:

**as-is**
total 0.356sec (50,000calls, 7microsec/call)

**to-be**
total 0.005sec (50,000calls, 0microsec/call) 🆙 

`ast-index/base:create-indexes`:

**as-is**
total 1.169sec (2calls)

**to-be**
total 0.25sec (2calls) 🆙 
