### PR TITLE
Chang to get class hierarchy from bytecode

### DIFF
--- a/path.lisp
+++ b/path.lisp
@@ -15,6 +15,8 @@
      (concatenate 'string a b))))
 
 (defun get-variable-names (sequence)
+  (unless sequence (return-from get-variable-names))
+
   (loop for c across sequence
         with begin-token
         with variable

--- a/plugin/spring/traversal/java.lisp
+++ b/plugin/spring/traversal/java.lisp
@@ -125,7 +125,7 @@
                        fq-name
                        #'(lambda (fqcn) (remove-if (lambda (a) (not (assoc :call-type a)))
                                                    (gethash :spring *rest-client-apis*)))
-                       (traversal-index traversal))))
+                       path)))
     (when matched-api
       (mapcar (lambda (server)
                 `((:host . ,(cdr (assoc :host server)))
@@ -151,14 +151,14 @@
                     (let* ((v (find-definition (ast-value param "name") ast))
                            (value (first (filter-by-name
                                            (get-asts v '("MODIFIERS" "ANNOTATION"))
-                                           "Value"))))
-                      (write-to-string
-                        (quri:uri-port (quri:uri 
-                                         (find-property
-                                           (first (get-variable-names
-                                                    (ast-value (first (get-asts value '("STRING_LITERAL")))
-                                                               "name")))
-                                           path))))))))))
+                                           "Value")))
+                           (url (find-property
+                                  (first (get-variable-names
+                                           (ast-value (first (get-asts value '("STRING_LITERAL")))
+                                                      "name")))
+                                  path)))
+                      (when url
+                        (write-to-string (quri:uri-port (quri:uri url))))))))))
     (multiple-value-bind (caller api) (find-caller
                                         (remove-if (lambda (a) (and (not (assoc :method a))
                                                                     (not (assoc :method-i a))))

--- a/plugin/spring/traversal/kotlin.lisp
+++ b/plugin/spring/traversal/kotlin.lisp
@@ -220,7 +220,7 @@
                        fq-name
                        #'(lambda (fqcn) (remove-if (lambda (a) (not (assoc :call-type a)))
                                                    (gethash :spring *rest-client-apis*)))
-                       (traversal-index traversal))))
+                       path)))
     (when matched-api
       (mapcar (lambda (server)
                 `((:host . ,(cdr (assoc :host server)))

--- a/test/traversal/java.lisp
+++ b/test/traversal/java.lisp
@@ -311,7 +311,7 @@
             "java.util.List.of-java.lang.String"
             #'(lambda (fqcn) '(((:fq-name . "java.util.List.of-java.lang.Object"))
                                ((:fq-name . "java.util.List.of-java.lang.Object[]"))))
-            *index*)))))
+            "src/main/java/p1/NewClassReference.java")))))
 
 (test matches-signature
   (with-fixture jvm-ctx (*java-path*)
@@ -320,7 +320,7 @@
           (inga/traversal/base::matches-signature
             "p2.ApiSignature-p2.ChildClass"
             "p2.ApiSignature-p2.ParentClass"
-            *index*)))))
+            "src/main/java/p2/ApiSignature.java")))))
 
 (test matches-signature-with-null
   (with-fixture jvm-ctx (*java-path*)
@@ -329,7 +329,7 @@
           (inga/traversal/base::matches-signature
             "java.lang.Object-equals-NULL"
             "java.lang.Object-equals-java.lang.Object"
-            *index*)))))
+            "src/main/java/p2/ApiSignature.java")))))
 
 (test matches-signature-with-additional-strings
   (with-fixture jvm-ctx (*java-path*)
@@ -339,7 +339,7 @@
           (inga/traversal/base::matches-signature
             "method-java.lang.String"
             "method-java.lang.String-java.lang.String[]"
-            *index*)))))
+            "src/main/java/p2/ApiSignature.java")))))
 
 (test find-class-hierarchy-with-app-class
   (with-fixture jvm-ctx (*java-path*)
@@ -347,7 +347,7 @@
           '("java.lang.Object"
             "p2.ParentClass"
             "p2.ChildClass")
-          (find-class-hierarchy "p2.ChildClass" *index*)))))
+          (find-class-hierarchy "p2.ChildClass" "src/main/java/p2/ApiSignature.java")))))
 
 (def-suite jdk17
            :in java)
@@ -538,7 +538,7 @@
           (inga/traversal/base::matches-signature
             "io.spring.application.CursorPager.CursorPager-java.util.ArrayList-io.spring.application.CursorPager$Direction-BOOLEAN"
             "io.spring.application.CursorPager.CursorPager-java.util.List-io.spring.application.CursorPager$Direction-BOOLEAN"
-            *index*)))))
+            "src/main/java/io/spring/application/ArticleQueryService.java")))))
 
 (test matches-signature-with-object-array
   (with-fixture jvm-ctx (*guava-modules*)
@@ -547,7 +547,7 @@
           (inga/traversal/base::matches-signature
             "com.google.common.collect.Lists.newArrayList-java.lang.String-java.lang.String"
             "com.google.common.collect.Lists.newArrayList-java.lang.Object[]"
-            *index*)))))
+            "guava-io/src/test/java/com/baeldung/guava/GuavaIOUnitTest.java")))))
 
 (test find-class-hierarchy-with-standard-class
   (with-fixture jvm-ctx (*lightrun-path*)
@@ -559,5 +559,7 @@
             "java.lang.constant.ConstantDesc"
             "java.lang.Object"
             "java.lang.String")
-          (find-class-hierarchy "java.lang.String" *index*)))))
+          (find-class-hierarchy
+            "java.lang.String"
+            "users-service/src/main/java/com/baeldung/usersservice/service/UsersService.java")))))
 


### PR DESCRIPTION
The hierarchy is now read from the bytecode to improve analysis performance instead of searching through all files.
However, it should be noted that this will not work correctly unless the source code is compiled in advance.