### PR TITLE
Evict the cache when the ClassLoader contents change

### DIFF
--- a/analyzer/java.lisp
+++ b/analyzer/java.lisp
@@ -285,7 +285,9 @@
                                 (let ((signatures (load-signatures fqcn path)))
                                   (if signatures
                                       signatures
-                                      (signal (make-condition 'signature-load-failed :path path)))))
+                                      (signal (make-condition 'signature-load-failed
+                                                              :path path
+                                                              :fq-class-name fqcn)))))
                             path)))
              (when method (cdr (assoc :return method)))))
           (t

--- a/cache.lisp
+++ b/cache.lisp
@@ -16,5 +16,7 @@
                    (if (eq cached-result 'empty) nil cached-result)
                    (let ((result (progn ,@body)))
                      (setf (gethash cache-key ,cache-sym) (or result 'empty))
-                     result))))))))
+                     result)))))
+       (defun ,(intern (concatenate 'string "EVICTC-" (string name))) ,params
+         (remhash (list ,@params) ,cache-sym)))))
 

--- a/docker/java/Dockerfile
+++ b/docker/java/Dockerfile
@@ -14,7 +14,7 @@ FROM eclipse-temurin:21-jdk-jammy
 ENV JAVAPARSER=0.3.5
 ENV KTPARSRER=0.1.6
 ENV SPRING_PROPERTY_LOADER=0.3.2
-ENV JVM_DEPENDENCY_LOADER=0.6.4
+ENV JVM_DEPENDENCY_LOADER=0.6.5
 
 COPY --from=build /inga/roswell/inga /usr/local/bin/
 

--- a/plugin/jvm-dependency-loader.lisp
+++ b/plugin/jvm-dependency-loader.lisp
@@ -2,8 +2,6 @@
   (:use #:cl
         #:inga/utils)
   (:import-from #:jsown)
-  (:import-from #:inga/cache
-                #:defunc)
   (:import-from #:inga/errors
                 #:inga-error-process-not-running
                 #:inga-error-process-failed)
@@ -130,7 +128,7 @@
 
 (defparameter *command-lock* (sb-thread:make-mutex))
 
-(defunc exec-command (process cmd)
+(defun exec-command (process cmd)
   (funtime
     (lambda ()
       (sb-thread:with-mutex (*command-lock*)

--- a/reporter.lisp
+++ b/reporter.lisp
@@ -3,6 +3,7 @@
   (:import-from #:jsown)
   (:import-from #:inga/analyzer/base
                 #:signature-load-failed
+                #:signature-load-failed-fq-class-name
                 #:signature-load-failed-path)
   (:import-from #:inga/file
                 #:convert-to-pos)
@@ -65,7 +66,9 @@
                                   ("type" . ,(get-type error))
                                   ("service". ,(find-service-name (signature-load-failed-path error)
                                                                   root-path))
-                                  ("path" . ,(signature-load-failed-path error))) results)))
+                                  ("path" . ,(signature-load-failed-path error))
+                                  ("fq-class-name" . ,(signature-load-failed-fq-class-name error)))
+                               results)))
                      finally (return (remove-duplicates results :test #'equal)))))
       (format out "~a"
               (jsown:to-json

--- a/test/analyzer/java.lisp
+++ b/test/analyzer/java.lisp
@@ -126,33 +126,6 @@
                                   *java-path*)
                                 '((:line . 5) (:offset . -1))))))))))))
 
-(test analyze-only-differences-when-second-analysis
-  (with-fixture jvm-ctx (*java-path*)
-    (let ((first-ranges
-            (list (create-range "src/main/java/integration/MethodDefinition.java" :line 4)))
-          (second-ranges
-            (list (create-range "src/main/java/integration/MethodDefinition.java" :start 4 :end 8))))
-      (analyze inga/test/helper::*ctx* first-ranges)
-      (analyze inga/test/helper::*ctx* second-ranges
-               :success (lambda (results)
-                          (is (equal
-                                '((((:type . "entrypoint")
-                                    (:origin
-                                      (:path . "src/main/java/integration/MethodDefinition.java")
-                                      (:name . "method1")
-                                      (:line . 4) (:offset . 17))
-                                    (:entrypoint
-                                      (:path . "src/main/java/integration/MethodReference.java")
-                                      (:name . "method")
-                                      (:line . 4) (:offset . 17))))
-                                  (((:type . "searching")
-                                    (:origin
-                                      (:path . "src/main/java/integration/MethodDefinition.java")
-                                      (:name . "method2")
-                                      (:line . 7) (:offset . 17)))))
-                                (mapcar (lambda (r) (mapcar (lambda (r) (get-file-pos r *java-path*)) r))
-                                        results))))))))
-
 (test find-definitions-for-constructor
   (with-fixture jvm-ctx (*java-path*)
     (is (equal


### PR DESCRIPTION
When running in server mode, the ClassLoader state changes dynamically, so evict the cache and re-analyze.