### PR TITLE
Find from scoped index for rest-server

### DIFF
--- a/analyzer/java.lisp
+++ b/analyzer/java.lisp
@@ -2,16 +2,16 @@
   (:use #:cl
         #:inga/analyzer/base
         #:inga/utils)
-  (:import-from #:alexandria
-                #:switch)
+  (:import-from #:inga/analyzer/jvm-helper
+                #:get-client-index)
+  (:import-from #:inga/analyzer/kotlin
+                #:analyzer-kotlin)
   (:import-from #:inga/ast-index
                 #:ast-index-paths
                 #:ast-index-root-path
                 #:create-indexes
                 #:get-ast
                 #:stop-indexes)
-  (:import-from #:inga/analyzer/kotlin
-                #:analyzer-kotlin)
   (:import-from #:inga/file
                 #:get-file-type)
   (:import-from #:inga/logger
@@ -77,7 +77,7 @@
   (let ((base-path (find-base-path path)))
     (when base-path (intern (namestring base-path) :keyword))))
 
-(defmethod get-scoped-index-paths-generic ((analyzer analyzer-java) pos)
+(defmethod get-scoped-index-paths-generic ((analyzer analyzer-java) pos config)
   (cond
     ((eq (cdr (assoc :type pos)) :module-private)
      (list (cdr (assoc :path pos))))
@@ -89,6 +89,8 @@
      (gethash (find-project-index-key (merge-pathnames (cdr (assoc :path pos))
                                                        (analyzer-path analyzer)))
               (gethash :module *file-index*)))
+    ((eq (cdr (assoc :type pos)) :rest-server)
+     (get-client-index pos (analyzer-path analyzer) config))
     (t
      (log-debug (format nil "start a slow-running full scan. pos: ~a" pos))
      (ast-index-paths (analyzer-index analyzer)))))

--- a/analyzer/jvm-helper.lisp
+++ b/analyzer/jvm-helper.lisp
@@ -1,0 +1,37 @@
+(defpackage #:inga/analyzer/jvm-helper
+  (:use #:cl
+        #:inga/analyzer/base)
+  (:import-from #:inga/plugin/jvm-helper
+                #:find-base-path)
+  (:export #:get-client-index))
+(in-package #:inga/analyzer/jvm-helper)
+
+(defun get-client-index (pos root-path config)
+  (let* ((server-base-path (enough-namestring
+                             (find-base-path
+                               (merge-pathnames
+                                 (cdr (assoc :path (cdr (assoc :file-pos pos))))
+                                 root-path))
+                             root-path))
+         (server (when config
+                   (find-if (lambda (s)
+                              (equal (namestring (pathname (concatenate 'string
+                                                                        (cdr (assoc :path s))
+                                                                        "/")))
+                                     server-base-path))
+                            (cdr (assoc :servers config)))))
+         (client-base-paths (mapcar (lambda (c)
+                                      (namestring
+                                        (pathname
+                                          (concatenate
+                                            'string
+                                            (namestring (merge-pathnames (cdr (assoc :path c))
+                                                                         root-path))
+                                            "/"))))
+                                    (when server (cdr (assoc :clients server))))))
+    (if server
+        (mapcan (lambda (c) (gethash (intern (namestring c) :keyword)
+                                     (gethash :module *file-index*)))
+                client-base-paths)
+        (gethash :rest-client *file-index*))))
+

--- a/cli.lisp
+++ b/cli.lisp
@@ -76,7 +76,8 @@
     (let* (failures
            (results (analyze ctx (diff-to-ranges (cdr (assoc :diff params))
                                                  (cdr (assoc :root-path params)))
-                             :failure (lambda (fs) (setf failures fs)))))
+                             :failure (lambda (fs) (setf failures fs))
+                             :config (cdr (assoc :config params)))))
       (output-error failures
                     (cdr (assoc :output-path params))
                     (cdr (assoc :root-path params)))

--- a/main.lisp
+++ b/main.lisp
@@ -15,6 +15,8 @@
   (:import-from #:inga/logger
                 #:log-debug
                 #:log-error)
+  (:import-from #:inga/yaml
+                #:parse-yaml)
   (:export #:command))
 (in-package #:inga/main)
 
@@ -27,7 +29,11 @@
                               (get-analysis-kinds (diff-to-ranges
                                                     (cdr (assoc :diff params))
                                                     (cdr (assoc :root-path params))))
-                              (get-env-kinds)))))
+                              (get-env-kinds))))
+           (config-path (merge-pathnames ".inga.yml" (cdr (assoc :root-path params)))))
+      (when (probe-file config-path)
+        (setf params
+              (acons :config (parse-yaml (alexandria:read-file-into-string config-path)) params)))
       (run (cdr (assoc :mode params)) language params))
     (inga-error (e) (format t "~a~%" e))))
 

--- a/plugin/spring/analyzer/java.lisp
+++ b/plugin/spring/analyzer/java.lisp
@@ -29,11 +29,6 @@
       "org.springframework.web.reactive.function.client.WebClient")
     :key-name "fqName"))
 
-(defmethod get-scoped-index-paths-generic :around ((analyzer analyzer-java) pos)
-  (if (eq (cdr (assoc :type pos)) :rest-server)
-      (gethash :rest-client *file-index*)
-      (call-next-method)))
-
 (defmethod find-definitions-generic :around ((analyzer analyzer-java) range)
   (loop
     with q = (make-queue)

--- a/plugin/spring/analyzer/kotlin.lisp
+++ b/plugin/spring/analyzer/kotlin.lisp
@@ -28,11 +28,6 @@
     "org.springframework.web.client.RestTemplate"
     :key-name "fqName"))
 
-(defmethod get-scoped-index-paths-generic :around ((analyzer analyzer-kotlin) pos)
-  (if (eq (cdr (assoc :type pos)) :rest-server)
-      (gethash :rest-client *file-index*)
-      (call-next-method)))
-
 (defmethod find-definitions-generic :around ((analyzer analyzer-kotlin) range)
   (loop
     with q = (make-queue)

--- a/server.lisp
+++ b/server.lisp
@@ -86,6 +86,7 @@
         (output-path (cdr (assoc :output-path params)))
         (temp-path (cdr (assoc :temp-path params)))
         (base-commit (cdr (assoc :base-commit params)))
+        (config (cdr (assoc :config params)))
         (msg (loop while *standard-input* do
                    (let* ((json (extract-json *standard-input*))
                           (result (when json (jsown:parse json))))
@@ -125,10 +126,10 @@
          (return-from handle-msg))
         (t
          (setf *processing-msg*
-               (process-msg-if-present msg ctx root-path output-path temp-path base-commit root-host-paths))))))
+               (process-msg-if-present msg ctx root-path output-path temp-path base-commit root-host-paths config))))))
   (handle-msg params ctx root-host-paths))
 
-(defun process-msg-if-present (msg ctx root-path output-path temp-path base-commit root-host-paths)
+(defun process-msg-if-present (msg ctx root-path output-path temp-path base-commit root-host-paths config)
   (when (or (not msg)
             (and *processing-msg* (sb-thread:thread-alive-p *processing-msg*)))
     (return-from process-msg-if-present *processing-msg*))
@@ -181,10 +182,11 @@
                      :success (lambda (results)
                                 (process-output-if-present results output-path root-path))
                      :failure (lambda (failures)
-                                (output-error failures output-path root-path)))
+                                (output-error failures output-path root-path))
+                     :config config)
                    `(()))
                output-path root-path)))))
-      (process-msg-if-present (dequeue-msg) ctx root-path output-path temp-path base-commit root-host-paths))))
+      (process-msg-if-present (dequeue-msg) ctx root-path output-path temp-path base-commit root-host-paths config))))
 
 (defun process-output-if-present (output output-path root-path)
   (unless output

--- a/test/analyzer/java.lisp
+++ b/test/analyzer/java.lisp
@@ -659,7 +659,7 @@
             '((:type . :module-private)
               (:path . "api-service/src/main/java/com/baeldung/apiservice/adapters/http/TasksController.java")
               (:fq-name . "com.baeldung.apiservice.adapters.http.TasksController.getUser-java.lang.String"))
-            *index*)))))
+            *index* nil)))))
 
 (test get-scoped-index-paths-with-module-public
   (with-fixture jvm-ctx (*lightrun-path*)
@@ -670,7 +670,7 @@
               '((:type . :module-public)
                 (:path . "api-service/src/main/java/com/baeldung/apiservice/adapters/users/UserRepository.java")
                 (:fq-name . "com.baeldung.apiservice.adapters.users.UserRepository.getUserById-java.lang.String"))
-              *index*))))))
+              *index* nil))))))
 
 (test not-matches-signature-with-no-args
   (with-fixture jvm-ctx (*lightrun-path*)

--- a/test/yaml.lisp
+++ b/test/yaml.lisp
@@ -9,41 +9,41 @@
 
 (test parse-yaml-with-single-server
   (is (equal
-        `(:servers
-           ((:clients
-              ((:name . "b")))
-            (:name . "a")))
+        `((:servers
+            ((:clients
+               ((:path . "b")))
+             (:path . "a"))))
         (parse-yaml "servers:
-                       - name: a
+                       - path: a
                          clients:
-                           - name: b"))))
+                           - path: b"))))
 
 (test parse-yaml-with-multiple-servers
   (is (equal
-        `(:servers
-           ((:clients
-              ((:name . "b")))
-            (:name . "a"))
-           ((:clients
-              ((:name . "d")))
-            (:name . "c")))
+        `((:servers
+            ((:clients
+               ((:path . "b")))
+             (:path . "a"))
+            ((:clients
+               ((:path . "d")))
+             (:path . "c"))))
         (parse-yaml "servers:
-                       - name: a
+                       - path: a
                          clients:
-                           - name: b
-                       - name: c
+                           - path: b
+                       - path: c
                          clients:
-                           - name: d"))))
+                           - path: d"))))
 
 (test parse-yaml-with-empty-clients
   (is (equal
-        `(:servers
-           ((:name . "a")))
+        `((:servers
+            ((:path . "a"))))
         (parse-yaml "servers:
-                       - name: a"))))
+                       - path: a"))))
 
 (test parse-yaml-with-blank-servers
   (is (equal
-        `(:servers)
+        `((:servers))
         (parse-yaml " servers:"))))
 

--- a/yaml.lisp
+++ b/yaml.lisp
@@ -18,10 +18,10 @@
                                   0 (- indent prev-indent))))
             (when (< indent-diff 0) (pop stack))
 
-            (when (uiop:string-prefix-p "- name:" trim-line)
+            (when (uiop:string-prefix-p "- path:" trim-line)
               (setf (cdr (first stack))
                     (append (cdr (first stack))
-                            (list `((:name . ,(string-trim '(#\Space) (subseq trim-line 7))))))))
+                            (list `((:path . ,(string-trim '(#\Space) (subseq trim-line 7))))))))
             (when (uiop:string-prefix-p "clients:" trim-line)
               (setf (car (last (cdar stack)))
                     (acons :clients nil (car (last (cdar stack)))))
@@ -31,5 +31,5 @@
 
             (when indent
               (setf prev-indent indent)))
-          finally (return (car (last stack))))))
+          finally (return (list (car (last stack)))))))
 


### PR DESCRIPTION
Searching all modules when searching for a client is very slow, so if there is a configuration file, narrow the search target.